### PR TITLE
Support 'in' location option for grape-swagger compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#8](https://github.com/numbata/grape-oas/pull/8): Add OAS2 parameter schema constraint export with enum normalization and retain zero-valued constraints across OAS exporters. - [@numbata](https://github.com/numbata).
 - [#9](https://github.com/numbata/grape-oas/pull/9): Treat GET/HEAD/DELETE as bodyless by default via shared constants and tests - [@numbata](https://github.com/numbata).
+- [#10](https://github.com/numbata/grape-oas/pull/10): Add grape-swagger compatible `in:` location syntax for parameters alongside `param_type` - [@numbata](https://github.com/numbata).
 
 ## [1.0.0] - 2025-12-06
 

--- a/lib/grape_oas/api_model_builders/request_params_support/param_location_resolver.rb
+++ b/lib/grape_oas/api_model_builders/request_params_support/param_location_resolver.rb
@@ -59,6 +59,20 @@ module GrapeOAS
         class << self
           private
 
+          # Extracts the parameter location from the specification.
+          # Supports both `param_type` and `in` options for grape-swagger compatibility.
+          #
+          # Precedence (highest to lowest):
+          #   1. `param_type` option (e.g., `documentation: { param_type: 'query' }`)
+          #   2. `in` option (e.g., `documentation: { in: 'query' }`)
+          #   3. Falls back to "query" if neither is specified
+          #
+          # Note: If both `param_type` and `in` are specified, `param_type` takes precedence.
+          # For example, `{ param_type: 'query', in: 'body' }` will be treated as query.
+          #
+          # @param spec [Hash] the parameter specification
+          # @param route [Object] the Grape route object
+          # @return [String] the parameter location
           def extract_from_spec(spec, route)
             # If body_name is set on the route, treat non-path params as body by default
             param_type = spec.dig(:documentation, :param_type)
@@ -66,6 +80,7 @@ module GrapeOAS
             return "body" if route.options[:body_name] && !param_type && !in_location
 
             # Support both param_type and in for grape-swagger compatibility
+            # param_type takes precedence over in when both are specified
             (param_type || in_location)&.to_s&.downcase || "query"
           end
         end

--- a/test/grape_oas/api_model_builders/request_params_location_test.rb
+++ b/test/grape_oas/api_model_builders/request_params_location_test.rb
@@ -212,6 +212,105 @@ module GrapeOAS
         assert(header_params.any? { |p| p.name == "authorization" })
       end
 
+      # === grape-swagger compatible `in:` location syntax ===
+
+      def test_in_body_location
+        api_class = Class.new(Grape::API) do
+          format :json
+          params do
+            requires :payload, type: Hash, documentation: { in: "body" }
+          end
+          post "webhook" do
+            {}
+          end
+        end
+
+        route = api_class.routes.first
+        op = build_operation(route, api_class)
+
+        refute_nil op.request_body, "in: 'body' should create request body"
+      end
+
+      def test_in_query_location
+        api_class = Class.new(Grape::API) do
+          format :json
+          params do
+            requires :filter, type: String, documentation: { in: "query" }
+          end
+          post "search" do
+            []
+          end
+        end
+
+        route = api_class.routes.first
+        op = build_operation(route, api_class)
+
+        query_params = op.parameters.select { |p| p.location == "query" }
+
+        assert(query_params.any? { |p| p.name == "filter" }, "in: 'query' should set query location")
+      end
+
+      def test_in_header_location
+        api_class = Class.new(Grape::API) do
+          format :json
+          params do
+            requires :x_api_key, type: String, documentation: { in: "header" }
+          end
+          get "secure" do
+            {}
+          end
+        end
+
+        route = api_class.routes.first
+        op = build_operation(route, api_class)
+
+        header_params = op.parameters.select { |p| p.location == "header" }
+
+        assert(header_params.any? { |p| p.name == "x_api_key" }, "in: 'header' should set header location")
+      end
+
+      def test_in_path_location_explicit
+        api_class = Class.new(Grape::API) do
+          format :json
+          params do
+            requires :id, type: Integer, documentation: { in: "path" }
+          end
+          get ":id" do
+            {}
+          end
+        end
+
+        route = api_class.routes.first
+        op = build_operation(route, api_class)
+
+        path_params = op.parameters.select { |p| p.location == "path" }
+
+        assert(path_params.any? { |p| p.name == "id" }, "in: 'path' should set path location")
+      end
+
+      # === param_type takes precedence over in: when both specified ===
+
+      def test_param_type_takes_precedence_over_in
+        api_class = Class.new(Grape::API) do
+          format :json
+          params do
+            requires :filter, type: String, documentation: { param_type: "query", in: "body" }
+          end
+          post "search" do
+            []
+          end
+        end
+
+        route = api_class.routes.first
+        op = build_operation(route, api_class)
+
+        query_params = op.parameters.select { |p| p.location == "query" }
+
+        # param_type: 'query' should take precedence over in: 'body'
+        assert(query_params.any? { |p| p.name == "filter" }, "param_type should take precedence over in:")
+        assert_nil op.request_body, "param_type: 'query' should prevent body creation despite in: 'body'"
+      end
+
       # === Multiple path params in nested route ===
 
       def test_multiple_path_params


### PR DESCRIPTION
Add support for `documentation: { in: 'body' }` syntax in addition to the existing `documentation: { param_type: 'body' }` for better compatibility with grape-swagger conventions.