### PR TITLE
Fix Array<Array<...>> double-wrap when is_array: true meets typed array type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#58](https://github.com/numbata/grape-oas/pull/58): Fix contract extraction compatibility with Grape 3.2 - [@numbata](https://github.com/numbata).
 - Your contribution here
 
+## [Unreleased]
+
+### Fixed
+
+- [#57](https://github.com/numbata/grape-oas/pull/57): Fix `Array<Array<...>>` double-wrap when `is_array: true` is used with typed array notation like `type: [String]` — the redundant `is_array` flag no longer produces a nested array schema - [@numbata](https://github.com/numbata).
+
 ## [1.3.0] - 2026-03-27
 
 ### Added
@@ -28,7 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- [#57](https://github.com/numbata/grape-oas/pull/57): Fix `Array<Array<...>>` double-wrap when `is_array: true` is used with typed array notation like `type: [String]` — the redundant `is_array` flag no longer produces a nested array schema - [@numbata](https://github.com/numbata).
 - [#55](https://github.com/numbata/grape-oas/pull/55): Preserve enum values on cached entity schemas — dup the shared schema before applying enum instead of silently discarding the constraint; emit a warning naming the entity - [@numbata](https://github.com/numbata).
 - [#50](https://github.com/numbata/grape-oas/pull/50): Fix `[false]` enum silently dropped — `[false].any?` returns `false` in Ruby, causing boolean-only enum constraints to be discarded - [@numbata](https://github.com/numbata).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,12 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [#52](https://github.com/numbata/grape-oas/pull/52): Extract `SchemaConstraints` — centralizes numeric/string constraint application (min/max, exclusive flags, length, pattern) and adds `exclusive_minimum`/`exclusive_maximum` support - [@numbata](https://github.com/numbata).
-- [#56](https://github.com/numbata/grape-oas/pull/56): Make `NestingMerger` depth-cap warning actionable — include property name and depth cap value in the message - [@numbata](https://github.com/numbata).
 - [#50](https://github.com/numbata/grape-oas/pull/50): Extract `ValuesNormalizer` — consolidates Proc/Set/Hash value normalization into a single module used by both request params and entity exposures - [@numbata](https://github.com/numbata).
 
 ### Fixed
 
 - [#55](https://github.com/numbata/grape-oas/pull/55): Preserve enum values on cached entity schemas — dup the shared schema before applying enum instead of silently discarding the constraint; emit a warning naming the entity - [@numbata](https://github.com/numbata).
+- [#56](https://github.com/numbata/grape-oas/pull/56): Make `NestingMerger` depth-cap warning actionable — include property name and depth cap value in the message - [@numbata](https://github.com/numbata).
 - [#50](https://github.com/numbata/grape-oas/pull/50): Fix `[false]` enum silently dropped — `[false].any?` returns `false` in Ruby, causing boolean-only enum constraints to be discarded - [@numbata](https://github.com/numbata).
 
 - [#49](https://github.com/numbata/grape-oas/pull/49): Fix OOM on wide string range expansion in `values:` — replace unbounded `range.to_a` with bounded enumeration; non-numeric ranges on numeric schemas and numeric ranges on non-numeric schemas now warn and are ignored instead of silently producing invalid output - [@numbata](https://github.com/numbata).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [#58](https://github.com/numbata/grape-oas/pull/58): Fix contract extraction compatibility with Grape 3.2 - [@numbata](https://github.com/numbata).
-- Your contribution here
-
-## [Unreleased]
-
-### Fixed
-
 - [#57](https://github.com/numbata/grape-oas/pull/57): Fix `Array<Array<...>>` double-wrap when `is_array: true` is used with typed array notation like `type: [String]` — the redundant `is_array` flag no longer produces a nested array schema - [@numbata](https://github.com/numbata).
+- Your contribution here
 
 ## [1.3.0] - 2026-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [#52](https://github.com/numbata/grape-oas/pull/52): Extract `SchemaConstraints` — centralizes numeric/string constraint application (min/max, exclusive flags, length, pattern) and adds `exclusive_minimum`/`exclusive_maximum` support - [@numbata](https://github.com/numbata).
+- [#56](https://github.com/numbata/grape-oas/pull/56): Make `NestingMerger` depth-cap warning actionable — include property name and depth cap value in the message - [@numbata](https://github.com/numbata).
 - [#50](https://github.com/numbata/grape-oas/pull/50): Extract `ValuesNormalizer` — consolidates Proc/Set/Hash value normalization into a single module used by both request params and entity exposures - [@numbata](https://github.com/numbata).
 
 ### Fixed
 
 - [#55](https://github.com/numbata/grape-oas/pull/55): Preserve enum values on cached entity schemas — dup the shared schema before applying enum instead of silently discarding the constraint; emit a warning naming the entity - [@numbata](https://github.com/numbata).
-- [#56](https://github.com/numbata/grape-oas/pull/56): Make `NestingMerger` depth-cap warning actionable — include property name and depth cap value in the message - [@numbata](https://github.com/numbata).
 - [#50](https://github.com/numbata/grape-oas/pull/50): Fix `[false]` enum silently dropped — `[false].any?` returns `false` in Ruby, causing boolean-only enum constraints to be discarded - [@numbata](https://github.com/numbata).
 
 - [#49](https://github.com/numbata/grape-oas/pull/49): Fix OOM on wide string range expansion in `values:` — replace unbounded `range.to_a` with bounded enumeration; non-numeric ranges on numeric schemas and numeric ranges on non-numeric schemas now warn and are ignored instead of silently producing invalid output - [@numbata](https://github.com/numbata).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#57](https://github.com/numbata/grape-oas/pull/57): Fix `Array<Array<...>>` double-wrap when `is_array: true` is used with typed array notation like `type: [String]` — the redundant `is_array` flag no longer produces a nested array schema - [@numbata](https://github.com/numbata).
 - [#55](https://github.com/numbata/grape-oas/pull/55): Preserve enum values on cached entity schemas — dup the shared schema before applying enum instead of silently discarding the constraint; emit a warning naming the entity - [@numbata](https://github.com/numbata).
 - [#50](https://github.com/numbata/grape-oas/pull/50): Fix `[false]` enum silently dropped — `[false].any?` returns `false` in Ruby, causing boolean-only enum constraints to be discarded - [@numbata](https://github.com/numbata).
 

--- a/lib/grape_oas/api_model_builders/concerns/type_resolver.rb
+++ b/lib/grape_oas/api_model_builders/concerns/type_resolver.rb
@@ -12,13 +12,8 @@ module GrapeOAS
       # Centralizes Ruby type to OpenAPI schema type resolution.
       # Used by request builders and introspectors to avoid duplicated type switching logic.
       module TypeResolver
-        # Regex fragment for a Ruby constant name, optionally namespaced: "String", "MyModule::MyType"
         CONST_NAME = /(?:::)?[A-Z]\w*(?:::[A-Z]\w*)*/
-
-        # Regex to match Grape's typed array notation like "[String]", "[Integer]", "[MyModule::MyType]"
         TYPED_ARRAY_PATTERN = /\A\[(#{CONST_NAME})\]\z/
-
-        # Regex to match Grape's multi-type notation like "[String, Integer]", "[String, Float]"
         MULTI_TYPE_PATTERN = /\A\[(#{CONST_NAME}(?:,\s*#{CONST_NAME})+)\]\z/
 
         # Resolves a Ruby class or type name to its OpenAPI schema type string.

--- a/lib/grape_oas/api_model_builders/concerns/type_resolver.rb
+++ b/lib/grape_oas/api_model_builders/concerns/type_resolver.rb
@@ -12,9 +12,8 @@ module GrapeOAS
       # Centralizes Ruby type to OpenAPI schema type resolution.
       # Used by request builders and introspectors to avoid duplicated type switching logic.
       module TypeResolver
-        CONST_NAME = /(?:::)?[A-Z]\w*(?:::[A-Z]\w*)*/
-        TYPED_ARRAY_PATTERN = /\A\[(#{CONST_NAME})\]\z/
-        MULTI_TYPE_PATTERN = /\A\[(#{CONST_NAME}(?:,\s*#{CONST_NAME})+)\]\z/
+        TYPED_ARRAY_PATTERN = Constants::TypePatterns::TYPED_ARRAY
+        MULTI_TYPE_PATTERN = Constants::TypePatterns::MULTI_TYPE
 
         # Resolves a Ruby class or type name to its OpenAPI schema type string.
         # Handles both Ruby classes (Integer, Float) and string type names ("integer", "float").
@@ -63,7 +62,7 @@ module GrapeOAS
           return nil unless type.is_a?(String)
 
           match = type.match(TYPED_ARRAY_PATTERN)
-          match ? match[1] : nil
+          match ? match[:inner] : nil
         end
 
         # Checks if type is a multi-type notation like "[String, Integer]"

--- a/lib/grape_oas/api_model_builders/concerns/type_resolver.rb
+++ b/lib/grape_oas/api_model_builders/concerns/type_resolver.rb
@@ -12,11 +12,14 @@ module GrapeOAS
       # Centralizes Ruby type to OpenAPI schema type resolution.
       # Used by request builders and introspectors to avoid duplicated type switching logic.
       module TypeResolver
+        # Regex fragment for a Ruby constant name, optionally namespaced: "String", "MyModule::MyType"
+        CONST_NAME = /(?:::)?[A-Z]\w*(?:::[A-Z]\w*)*/
+
         # Regex to match Grape's typed array notation like "[String]", "[Integer]", "[MyModule::MyType]"
-        TYPED_ARRAY_PATTERN = /\A\[(\w+(?:::\w+)*)\]\z/
+        TYPED_ARRAY_PATTERN = /\A\[(#{CONST_NAME})\]\z/
 
         # Regex to match Grape's multi-type notation like "[String, Integer]", "[String, Float]"
-        MULTI_TYPE_PATTERN = /\A\[(\w+(?:::\w+)*(?:,\s*\w+(?:::\w+)*)+)\]\z/
+        MULTI_TYPE_PATTERN = /\A\[(#{CONST_NAME}(?:,\s*#{CONST_NAME})+)\]\z/
 
         # Resolves a Ruby class or type name to its OpenAPI schema type string.
         # Handles both Ruby classes (Integer, Float) and string type names ("integer", "float").

--- a/lib/grape_oas/api_model_builders/request_params_support/param_schema_builder.rb
+++ b/lib/grape_oas/api_model_builders/request_params_support/param_schema_builder.rb
@@ -33,12 +33,19 @@ module GrapeOAS
 
           return build_entity_array_schema(spec, raw_type, doc_type) if entity_array_type?(type_source, doc_type, spec)
           return build_doc_entity_array_schema(doc_type) if doc[:is_array] && grape_entity?(doc_type)
+
           # When raw_type is already a typed array like "[String]", is_array: true is
           # redundant — the type itself carries array semantics. Falling through to
           # build_primitive_array_schema would resolve "[String]" → type "array" and
           # produce Array<Array<...>>. Use type_resolvers instead to build it correctly.
           if doc[:is_array] && extract_typed_array_member(raw_type)
-            return GrapeOAS.type_resolvers.build_schema(raw_type) || build_simple_array_schema
+            resolved = GrapeOAS.type_resolvers.build_schema(raw_type)
+            unless resolved
+              GrapeOAS.logger.warn(
+                "type_resolvers could not resolve '#{raw_type}'; falling back to Array<string>",
+              )
+            end
+            return resolved || build_simple_array_schema
           end
           return build_primitive_array_schema(doc_type, raw_type) if doc[:is_array]
           return build_entity_schema(doc_type) if grape_entity?(doc_type)

--- a/lib/grape_oas/api_model_builders/request_params_support/param_schema_builder.rb
+++ b/lib/grape_oas/api_model_builders/request_params_support/param_schema_builder.rb
@@ -34,10 +34,8 @@ module GrapeOAS
           return build_entity_array_schema(spec, raw_type, doc_type) if entity_array_type?(type_source, doc_type, spec)
           return build_doc_entity_array_schema(doc_type) if doc[:is_array] && grape_entity?(doc_type)
 
-          # When raw_type is already a typed array like "[String]", is_array: true is
-          # redundant — the type itself carries array semantics. Falling through to
-          # build_primitive_array_schema would resolve "[String]" → type "array" and
-          # produce Array<Array<...>>. Use type_resolvers instead to build it correctly.
+          # is_array: true on a typed array like "[String]" is redundant and would
+          # double-wrap it as Array<Array<...>> via build_primitive_array_schema.
           if doc[:is_array] && extract_typed_array_member(raw_type)
             resolved = GrapeOAS.type_resolvers.build_schema(raw_type)
             unless resolved

--- a/lib/grape_oas/api_model_builders/request_params_support/param_schema_builder.rb
+++ b/lib/grape_oas/api_model_builders/request_params_support/param_schema_builder.rb
@@ -33,6 +33,13 @@ module GrapeOAS
 
           return build_entity_array_schema(spec, raw_type, doc_type) if entity_array_type?(type_source, doc_type, spec)
           return build_doc_entity_array_schema(doc_type) if doc[:is_array] && grape_entity?(doc_type)
+          # When raw_type is already a typed array like "[String]", is_array: true is
+          # redundant — the type itself carries array semantics. Falling through to
+          # build_primitive_array_schema would resolve "[String]" → type "array" and
+          # produce Array<Array<...>>. Use type_resolvers instead to build it correctly.
+          if doc[:is_array] && extract_typed_array_member(raw_type)
+            return GrapeOAS.type_resolvers.build_schema(raw_type) || build_simple_array_schema
+          end
           return build_primitive_array_schema(doc_type, raw_type) if doc[:is_array]
           return build_entity_schema(doc_type) if grape_entity?(doc_type)
           return build_entity_schema(raw_type) if grape_entity?(raw_type)

--- a/lib/grape_oas/api_model_builders/request_params_support/param_schema_builder.rb
+++ b/lib/grape_oas/api_model_builders/request_params_support/param_schema_builder.rb
@@ -36,15 +36,7 @@ module GrapeOAS
 
           # is_array: true on a typed array like "[String]" is redundant and would
           # double-wrap it as Array<Array<...>> via build_primitive_array_schema.
-          if doc[:is_array] && extract_typed_array_member(raw_type)
-            resolved = GrapeOAS.type_resolvers.build_schema(raw_type)
-            unless resolved
-              GrapeOAS.logger.warn(
-                "type_resolvers could not resolve '#{raw_type}'; falling back to Array<string>",
-              )
-            end
-            return resolved || build_simple_array_schema
-          end
+          return GrapeOAS.type_resolvers.build_schema(raw_type) if doc[:is_array] && extract_typed_array_member(raw_type)
           return build_primitive_array_schema(doc_type, raw_type) if doc[:is_array]
           return build_entity_schema(doc_type) if grape_entity?(doc_type)
           return build_entity_schema(raw_type) if grape_entity?(raw_type)

--- a/lib/grape_oas/constants.rb
+++ b/lib/grape_oas/constants.rb
@@ -51,6 +51,15 @@ module GrapeOAS
     # Prevents OOM on wide string ranges (e.g. "a".."zzzzzz").
     MAX_ENUM_RANGE_SIZE = 100
 
+    # Regex patterns for Grape's stringified type notations.
+    # Grape converts `type: [SomeClass]` to "[SomeClass]" and
+    # `type: [String, Integer]` to "[String, Integer]" for documentation.
+    module TypePatterns
+      CONST_NAME = /(?:::)?[A-Z]\w*(?:::[A-Z]\w*)*/
+      TYPED_ARRAY = /\A\[(?<inner>#{CONST_NAME})\]\z/
+      MULTI_TYPE = /\A\[(#{CONST_NAME}(?:,\s*#{CONST_NAME})+)\]\z/
+    end
+
     # Default values for OpenAPI spec when not provided by user
     module Defaults
       LICENSE_NAME = "Proprietary"

--- a/lib/grape_oas/type_resolvers/array_resolver.rb
+++ b/lib/grape_oas/type_resolvers/array_resolver.rb
@@ -20,7 +20,7 @@ module GrapeOAS
     class ArrayResolver
       extend Base
 
-      ARRAY_PATTERN = ApiModelBuilders::Concerns::TypeResolver::TYPED_ARRAY_PATTERN
+      ARRAY_PATTERN = Constants::TypePatterns::TYPED_ARRAY
 
       class << self
         def handles?(type)
@@ -52,7 +52,7 @@ module GrapeOAS
 
         def extract_inner_type(type)
           match = type.match(ARRAY_PATTERN)
-          match[1] if match
+          match[:inner] if match
         end
 
         def build_schema_from_class(klass)

--- a/lib/grape_oas/type_resolvers/array_resolver.rb
+++ b/lib/grape_oas/type_resolvers/array_resolver.rb
@@ -20,9 +20,7 @@ module GrapeOAS
     class ArrayResolver
       extend Base
 
-      # Pattern to match Grape's array notation: "[Type]" or "[Module::Type]"
-      # Intentionally narrow: avoid treating multi-type strings like "[String, Integer]" as arrays.
-      ARRAY_PATTERN = /\A\[(?<inner>(?:::)?[A-Z]\w*(?:::[A-Z]\w*)*)\]\z/
+      ARRAY_PATTERN = ApiModelBuilders::Concerns::TypeResolver::TYPED_ARRAY_PATTERN
 
       class << self
         def handles?(type)
@@ -54,7 +52,7 @@ module GrapeOAS
 
         def extract_inner_type(type)
           match = type.match(ARRAY_PATTERN)
-          match[:inner] if match
+          match[1] if match
         end
 
         def build_schema_from_class(klass)

--- a/lib/grape_oas/type_resolvers/array_resolver.rb
+++ b/lib/grape_oas/type_resolvers/array_resolver.rb
@@ -20,13 +20,13 @@ module GrapeOAS
     class ArrayResolver
       extend Base
 
-      ARRAY_PATTERN = Constants::TypePatterns::TYPED_ARRAY
+      TYPED_ARRAY_PATTERN = Constants::TypePatterns::TYPED_ARRAY
 
       class << self
         def handles?(type)
           return false unless type.is_a?(String)
 
-          type.match?(ARRAY_PATTERN)
+          type.match?(TYPED_ARRAY_PATTERN)
         end
 
         def build_schema(type)
@@ -51,7 +51,7 @@ module GrapeOAS
         private
 
         def extract_inner_type(type)
-          match = type.match(ARRAY_PATTERN)
+          match = type.match(TYPED_ARRAY_PATTERN)
           match[:inner] if match
         end
 

--- a/test/grape_oas/api_model_builders/request_params_array_test.rb
+++ b/test/grape_oas/api_model_builders/request_params_array_test.rb
@@ -295,6 +295,142 @@ module GrapeOAS
 
         assert_nil ids_param.collection_format
       end
+
+      # === Namespaced types ===
+
+      def test_array_of_namespaced_type_with_uuid
+        # Simulate what Grape stores when you use type: [MyModule::Types::UUID]
+        # Grape converts this to the string "[MyModule::Types::UUID]"
+        api_class = Class.new(Grape::API) do
+          format :json
+          params do
+            # Using a string that simulates namespaced type (Grape stringifies these)
+            requires :slide_ids, type: "[MyModule::Types::UUID]", documentation: { param_type: "body" }
+          end
+          post "items" do
+            {}
+          end
+        end
+
+        route = api_class.routes.first
+        builder = RequestParams.new(api: @api, route: route)
+        body_schema, _params = builder.build
+
+        slide_ids = body_schema.properties["slide_ids"]
+
+        assert_equal "array", slide_ids.type
+        assert_equal "string", slide_ids.items.type
+        assert_equal "uuid", slide_ids.items.format
+      end
+
+      def test_array_of_namespaced_type_with_datetime
+        api_class = Class.new(Grape::API) do
+          format :json
+          params do
+            requires :timestamps, type: "[MyModule::Types::DateTime]", documentation: { param_type: "body" }
+          end
+          post "items" do
+            {}
+          end
+        end
+
+        route = api_class.routes.first
+        builder = RequestParams.new(api: @api, route: route)
+        body_schema, _params = builder.build
+
+        timestamps = body_schema.properties["timestamps"]
+
+        assert_equal "array", timestamps.type
+        assert_equal "string", timestamps.items.type
+        assert_equal "date-time", timestamps.items.format
+      end
+
+      def test_array_of_deeply_namespaced_type
+        api_class = Class.new(Grape::API) do
+          format :json
+          params do
+            requires :ids, type: "[Very::Deeply::Nested::Module::Type]", documentation: { param_type: "body" }
+          end
+          post "items" do
+            {}
+          end
+        end
+
+        route = api_class.routes.first
+        builder = RequestParams.new(api: @api, route: route)
+        body_schema, _params = builder.build
+
+        ids = body_schema.properties["ids"]
+
+        assert_equal "array", ids.type
+        # Unknown namespaced types default to string
+        assert_equal "string", ids.items.type
+      end
+
+      # === Entity arrays ===
+
+      def test_entity_typed_array_with_is_array_does_not_double_wrap
+        entity = Class.new(Grape::Entity) do
+          expose :id, documentation: { type: Integer }
+          expose :name, documentation: { type: String }
+        end
+
+        Object.const_set(:TestEntityIsArrayWrap, entity) unless defined?(TestEntityIsArrayWrap)
+
+        api_class = Class.new(Grape::API) do
+          format :json
+          params do
+            requires :users, type: "[TestEntityIsArrayWrap]", documentation: { is_array: true, param_type: "body" }
+          end
+          post "batch" do
+            {}
+          end
+        end
+
+        route = api_class.routes.first
+        builder = RequestParams.new(api: @api, route: route)
+        body_schema, _params = builder.build
+
+        users = body_schema.properties["users"]
+
+        assert_equal "array", users.type
+        assert_equal "object", users.items.type
+        assert users.items.properties.key?("id")
+        assert users.items.properties.key?("name")
+      end
+
+      def test_array_of_entity_in_typed_notation
+        # Define an entity class for testing
+        user_entity = Class.new(Grape::Entity) do
+          expose :id, documentation: { type: Integer }
+          expose :name, documentation: { type: String }
+        end
+
+        # Make the entity accessible via const_get
+        Object.const_set(:TestUserEntityForArray, user_entity) unless defined?(TestUserEntityForArray)
+
+        api_class = Class.new(Grape::API) do
+          format :json
+          params do
+            requires :users, type: "[TestUserEntityForArray]", documentation: { param_type: "body" }
+          end
+          post "batch" do
+            {}
+          end
+        end
+
+        route = api_class.routes.first
+        builder = RequestParams.new(api: @api, route: route)
+        body_schema, _params = builder.build
+
+        users = body_schema.properties["users"]
+
+        assert_equal "array", users.type
+        # Items should be an object schema from the entity introspector
+        assert_equal "object", users.items.type
+        assert users.items.properties.key?("id")
+        assert users.items.properties.key?("name")
+      end
     end
   end
 end

--- a/test/grape_oas/api_model_builders/request_params_array_test.rb
+++ b/test/grape_oas/api_model_builders/request_params_array_test.rb
@@ -300,12 +300,9 @@ module GrapeOAS
 
       def test_array_of_namespaced_type_with_uuid
         skip "Grape >= 3.2 rejects string type notation" if Gem::Version.new(Grape::VERSION) >= Gem::Version.new("3.2")
-        # Simulate what Grape stores when you use type: [MyModule::Types::UUID]
-        # Grape converts this to the string "[MyModule::Types::UUID]"
         api_class = Class.new(Grape::API) do
           format :json
           params do
-            # Using a string that simulates namespaced type (Grape stringifies these)
             requires :slide_ids, type: "[MyModule::Types::UUID]", documentation: { param_type: "body" }
           end
           post "items" do
@@ -366,7 +363,6 @@ module GrapeOAS
         ids = body_schema.properties["ids"]
 
         assert_equal "array", ids.type
-        # Unknown namespaced types default to string
         assert_equal "string", ids.items.type
       end
 
@@ -405,13 +401,11 @@ module GrapeOAS
 
       def test_array_of_entity_in_typed_notation
         skip "Grape >= 3.2 rejects string type notation" if Gem::Version.new(Grape::VERSION) >= Gem::Version.new("3.2")
-        # Define an entity class for testing
         user_entity = Class.new(Grape::Entity) do
           expose :id, documentation: { type: Integer }
           expose :name, documentation: { type: String }
         end
 
-        # Make the entity accessible via const_get
         Object.const_set(:TestUserEntityForArray, user_entity) unless defined?(TestUserEntityForArray)
 
         api_class = Class.new(Grape::API) do
@@ -431,7 +425,6 @@ module GrapeOAS
         users = body_schema.properties["users"]
 
         assert_equal "array", users.type
-        # Items should be an object schema from the entity introspector
         assert_equal "object", users.items.type
         assert users.items.properties.key?("id")
         assert users.items.properties.key?("name")

--- a/test/grape_oas/api_model_builders/request_params_array_test.rb
+++ b/test/grape_oas/api_model_builders/request_params_array_test.rb
@@ -380,7 +380,7 @@ module GrapeOAS
           expose :name, documentation: { type: String }
         end
 
-        Object.const_set(:TestEntityIsArrayWrap, entity) unless defined?(TestEntityIsArrayWrap)
+        Object.const_set(:TestEntityIsArrayWrap, entity)
 
         api_class = Class.new(Grape::API) do
           format :json
@@ -411,7 +411,7 @@ module GrapeOAS
           expose :name, documentation: { type: String }
         end
 
-        Object.const_set(:TestUserEntityForArray, user_entity) unless defined?(TestUserEntityForArray)
+        Object.const_set(:TestUserEntityForArray, user_entity)
 
         api_class = Class.new(Grape::API) do
           format :json

--- a/test/grape_oas/api_model_builders/request_params_array_test.rb
+++ b/test/grape_oas/api_model_builders/request_params_array_test.rb
@@ -9,6 +9,11 @@ module GrapeOAS
         @api = GrapeOAS::ApiModel::API.new(title: "Test API", version: "1.0")
       end
 
+      def teardown
+        Object.send(:remove_const, :TestEntityIsArrayWrap) if defined?(TestEntityIsArrayWrap)
+        Object.send(:remove_const, :TestUserEntityForArray) if defined?(TestUserEntityForArray)
+      end
+
       # === Typed Array parameters ===
 
       def test_array_of_strings

--- a/test/grape_oas/api_model_builders/request_params_array_test.rb
+++ b/test/grape_oas/api_model_builders/request_params_array_test.rb
@@ -299,6 +299,7 @@ module GrapeOAS
       # === Namespaced types ===
 
       def test_array_of_namespaced_type_with_uuid
+        skip "Grape >= 3.2 rejects string type notation" if Gem::Version.new(Grape::VERSION) >= Gem::Version.new("3.2")
         # Simulate what Grape stores when you use type: [MyModule::Types::UUID]
         # Grape converts this to the string "[MyModule::Types::UUID]"
         api_class = Class.new(Grape::API) do
@@ -324,6 +325,7 @@ module GrapeOAS
       end
 
       def test_array_of_namespaced_type_with_datetime
+        skip "Grape >= 3.2 rejects string type notation" if Gem::Version.new(Grape::VERSION) >= Gem::Version.new("3.2")
         api_class = Class.new(Grape::API) do
           format :json
           params do
@@ -346,6 +348,7 @@ module GrapeOAS
       end
 
       def test_array_of_deeply_namespaced_type
+        skip "Grape >= 3.2 rejects string type notation" if Gem::Version.new(Grape::VERSION) >= Gem::Version.new("3.2")
         api_class = Class.new(Grape::API) do
           format :json
           params do
@@ -370,6 +373,7 @@ module GrapeOAS
       # === Entity arrays ===
 
       def test_entity_typed_array_with_is_array_does_not_double_wrap
+        skip "Grape >= 3.2 rejects string type notation" if Gem::Version.new(Grape::VERSION) >= Gem::Version.new("3.2")
         entity = Class.new(Grape::Entity) do
           expose :id, documentation: { type: Integer }
           expose :name, documentation: { type: String }
@@ -400,6 +404,7 @@ module GrapeOAS
       end
 
       def test_array_of_entity_in_typed_notation
+        skip "Grape >= 3.2 rejects string type notation" if Gem::Version.new(Grape::VERSION) >= Gem::Version.new("3.2")
         # Define an entity class for testing
         user_entity = Class.new(Grape::Entity) do
           expose :id, documentation: { type: Integer }

--- a/test/grape_oas/api_model_builders/request_params_test.rb
+++ b/test/grape_oas/api_model_builders/request_params_test.rb
@@ -377,27 +377,7 @@ module GrapeOAS
         api_class = Class.new(Grape::API) do
           format :json
           params do
-            optional :ids, type: [String], documentation: { is_array: true, param_type: "body" }
-          end
-          post "batch" do
-            {}
-          end
-        end
-
-        route = api_class.routes.first
-        builder = RequestParams.new(api: @api, route: route)
-        body_schema, _params = builder.build
-
-        ids = body_schema.properties["ids"]
-
-        assert_equal "array", ids.type
-        assert_equal "string", ids.items.type
-      end
-
-      def test_typed_array_integer_with_is_array_does_not_double_wrap
-        api_class = Class.new(Grape::API) do
-          format :json
-          params do
+            optional :tags, type: [String], documentation: { is_array: true, param_type: "body" }
             optional :counts, type: [Integer], documentation: { is_array: true, param_type: "body" }
           end
           post "batch" do
@@ -408,6 +388,11 @@ module GrapeOAS
         route = api_class.routes.first
         builder = RequestParams.new(api: @api, route: route)
         body_schema, _params = builder.build
+
+        tags = body_schema.properties["tags"]
+
+        assert_equal "array", tags.type
+        assert_equal "string", tags.items.type
 
         counts = body_schema.properties["counts"]
 

--- a/test/grape_oas/api_model_builders/request_params_test.rb
+++ b/test/grape_oas/api_model_builders/request_params_test.rb
@@ -374,9 +374,6 @@ module GrapeOAS
       end
 
       def test_typed_array_with_is_array_does_not_double_wrap
-        # type: [String] already implies an array; is_array: true is redundant.
-        # Previously this produced Array<Array<unknown>> because build_primitive_array_schema
-        # resolved "[String]" → type "array" and wrapped it again.
         api_class = Class.new(Grape::API) do
           format :json
           params do

--- a/test/grape_oas/api_model_builders/request_params_test.rb
+++ b/test/grape_oas/api_model_builders/request_params_test.rb
@@ -373,6 +373,51 @@ module GrapeOAS
         assert_equal "integer", ids.items.type
       end
 
+      def test_typed_array_with_is_array_does_not_double_wrap
+        # type: [String] already implies an array; is_array: true is redundant.
+        # Previously this produced Array<Array<unknown>> because build_primitive_array_schema
+        # resolved "[String]" → type "array" and wrapped it again.
+        api_class = Class.new(Grape::API) do
+          format :json
+          params do
+            optional :ids, type: [String], documentation: { is_array: true, param_type: "body" }
+          end
+          post "batch" do
+            {}
+          end
+        end
+
+        route = api_class.routes.first
+        builder = RequestParams.new(api: @api, route: route)
+        body_schema, _params = builder.build
+
+        ids = body_schema.properties["ids"]
+
+        assert_equal "array", ids.type
+        assert_equal "string", ids.items.type
+      end
+
+      def test_typed_array_integer_with_is_array_does_not_double_wrap
+        api_class = Class.new(Grape::API) do
+          format :json
+          params do
+            optional :counts, type: [Integer], documentation: { is_array: true, param_type: "body" }
+          end
+          post "batch" do
+            {}
+          end
+        end
+
+        route = api_class.routes.first
+        builder = RequestParams.new(api: @api, route: route)
+        body_schema, _params = builder.build
+
+        counts = body_schema.properties["counts"]
+
+        assert_equal "array", counts.type
+        assert_equal "integer", counts.items.type
+      end
+
       def test_hash_type_parameter
         api_class = Class.new(Grape::API) do
           format :json


### PR DESCRIPTION
## Summary

- When a param declares `type: [String]` and `documentation: { is_array: true }`, grape-oas was producing `Array<Array<unknown>>` instead of `Array<string>`
- Root cause: Grape stores `type: [String]` as the string `"[String]"` in `spec[:type]`. The `is_array: true` branch fires first and calls `build_primitive_array_schema`, which passes `"[String]"` to `resolve_schema_type` — that returns `"array"` (correctly recognizing it as an array notation), wrapping it in yet another array
- Fix: detect when `raw_type` is already a typed array notation before the generic `is_array` branch; delegate to `type_resolvers` instead, which correctly builds `Array<string>` via `ArrayResolver`

## Example

```ruby
# Grape param with typed array and redundant is_array:
optional :ids, type: [String], documentation: { is_array: true }

# Before (double-wrapped):
# { "type": "array", "items": { "type": "array" } }  # Array<Array<unknown>>

# After (correct):
# { "type": "array", "items": { "type": "string" } }  # Array<string>
```

`is_array: true` on a param whose type is already a typed array like `[String]` or `[Integer]` is redundant — the type itself carries array semantics. The fix ignores the redundant flag rather than erroring, preserving backward compatibility with APIs that set both.