### PR TITLE
Export `default` param values to OAS2 and OAS3 output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#58](https://github.com/numbata/grape-oas/pull/58): Fix contract extraction compatibility with Grape 3.2 - [@numbata](https://github.com/numbata).
 - [#57](https://github.com/numbata/grape-oas/pull/57): Fix `Array<Array<...>>` double-wrap when `is_array: true` is used with typed array notation like `type: [String]` — the redundant `is_array` flag no longer produces a nested array schema - [@numbata](https://github.com/numbata).
-- [#59](https://github.com/numbata/grape-oas/pull/59): Export `default` param values to oas2 and oas3 output - [@olivier-thatch](https://github.com/olivier-thatch).
+- [#59](https://github.com/numbata/grape-oas/pull/59): Export `default` param values to OAS2 and OAS3 output - [@olivier-thatch](https://github.com/olivier-thatch).
 - Your contribution here
 
 ## [1.3.0] - 2026-03-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#58](https://github.com/numbata/grape-oas/pull/58): Fix contract extraction compatibility with Grape 3.2 - [@numbata](https://github.com/numbata).
 - [#57](https://github.com/numbata/grape-oas/pull/57): Fix `Array<Array<...>>` double-wrap when `is_array: true` is used with typed array notation like `type: [String]` — the redundant `is_array` flag no longer produces a nested array schema - [@numbata](https://github.com/numbata).
+- [#59](https://github.com/numbata/grape-oas/pull/59): Export `default` param values to oas2 and oas3 output - [@olivier-thatch](https://github.com/olivier-thatch).
 - Your contribution here
 
 ## [1.3.0] - 2026-03-27

--- a/lib/grape_oas/api_model/schema.rb
+++ b/lib/grape_oas/api_model/schema.rb
@@ -11,7 +11,7 @@ module GrapeOAS
       VALID_ATTRIBUTES = %i[
         canonical_name type format properties items description
         required nullable enum additional_properties unevaluated_properties defs
-        examples extensions
+        examples default extensions
         min_length max_length pattern
         minimum maximum exclusive_minimum exclusive_maximum
         min_items max_items

--- a/lib/grape_oas/api_model_builders/request_params_support/schema_enhancer.rb
+++ b/lib/grape_oas/api_model_builders/request_params_support/schema_enhancer.rb
@@ -21,6 +21,7 @@ module GrapeOAS
           apply_format_and_example(schema, doc)
           SchemaConstraints.apply(schema, doc)
           apply_values(schema, spec)
+          apply_default(schema, spec, doc)
         end
 
         # Extracts nullable flag from a documentation hash.
@@ -43,6 +44,16 @@ module GrapeOAS
             end
             defs = extract_defs(doc)
             schema.defs = defs if defs.is_a?(Hash) && schema.respond_to?(:defs=)
+          end
+
+          def apply_default(schema, spec, doc)
+            return unless schema.respond_to?(:default=)
+
+            if spec.key?(:default)
+              schema.default = spec[:default]
+            elsif doc.key?(:default)
+              schema.default = doc[:default]
+            end
           end
 
           def apply_format_and_example(schema, doc)

--- a/lib/grape_oas/exporter/oas2/parameter.rb
+++ b/lib/grape_oas/exporter/oas2/parameter.rb
@@ -78,6 +78,7 @@ module GrapeOAS
           result["maxItems"] = schema.max_items if schema.respond_to?(:max_items) && !schema.max_items.nil?
           result["pattern"] = schema.pattern if schema.respond_to?(:pattern) && schema.pattern
           result["enum"] = normalize_enum(schema.enum, result["type"]) if schema.respond_to?(:enum) && schema.enum
+          result["default"] = schema.default if schema.respond_to?(:default) && !schema.default.nil?
         end
 
         def normalize_enum(enum_vals, type)

--- a/lib/grape_oas/exporter/oas2/schema.rb
+++ b/lib/grape_oas/exporter/oas2/schema.rb
@@ -52,6 +52,7 @@ module GrapeOAS
           schema_hash["example"] = @schema.examples if @schema.examples
           schema_hash["required"] = @schema.required if @schema.required && !@schema.required.empty?
           schema_hash["discriminator"] = @schema.discriminator if @schema.discriminator
+          schema_hash["default"] = @schema.default unless @schema.default.nil?
           schema_hash
         end
 

--- a/lib/grape_oas/exporter/oas3/schema.rb
+++ b/lib/grape_oas/exporter/oas3/schema.rb
@@ -51,6 +51,7 @@ module GrapeOAS
           end
           schema_hash["required"] = @schema.required if @schema.required && !@schema.required.empty?
           schema_hash["enum"] = normalize_enum(@schema.enum, schema_hash["type"]) if @schema.enum
+          schema_hash["default"] = @schema.default unless @schema.default.nil?
           schema_hash
         end
 

--- a/test/e2e/generate_default_value_test.rb
+++ b/test/e2e/generate_default_value_test.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GrapeOAS
+  # Verifies we carry through default values to all OAS versions.
+  class GenerateDefaultValueTest < Minitest::Test
+    # === OAS2 ===
+
+    def test_oas2_string_param_with_default_exports_default
+      api_class = Class.new(Grape::API) do
+        format :json
+        params do
+          optional :status, type: String, default: "pending"
+        end
+        get "items" do
+          {}
+        end
+      end
+
+      schema = GrapeOAS.generate(app: api_class, schema_type: :oas2)
+      parameters = schema["paths"]["/items"]["get"]["parameters"]
+      status_param = parameters.find { |p| p["name"] == "status" }
+
+      assert_equal "pending", status_param["default"]
+    end
+
+    def test_oas2_integer_param_with_default_exports_default
+      api_class = Class.new(Grape::API) do
+        format :json
+        params do
+          optional :page, type: Integer, default: 1
+        end
+        get "items" do
+          {}
+        end
+      end
+
+      schema = GrapeOAS.generate(app: api_class, schema_type: :oas2)
+      parameters = schema["paths"]["/items"]["get"]["parameters"]
+      page_param = parameters.find { |p| p["name"] == "page" }
+
+      assert_equal 1, page_param["default"]
+    end
+
+    def test_oas2_boolean_param_with_false_default_exports_default
+      api_class = Class.new(Grape::API) do
+        format :json
+        params do
+          optional :enabled, type: Grape::API::Boolean, default: false
+        end
+        get "settings" do
+          {}
+        end
+      end
+
+      schema = GrapeOAS.generate(app: api_class, schema_type: :oas2)
+      parameters = schema["paths"]["/settings"]["get"]["parameters"]
+      enabled_param = parameters.find { |p| p["name"] == "enabled" }
+
+      # false is a valid default — it must be present (not absent/nil)
+      assert enabled_param.key?("default"), "expected 'default' key to be present"
+      assert_equal false, enabled_param["default"]
+    end
+
+    def test_oas2_param_with_default_and_enum_exports_both
+      api_class = Class.new(Grape::API) do
+        format :json
+        params do
+          optional :role, type: String, values: %w[admin user guest], default: "user"
+        end
+        get "accounts" do
+          {}
+        end
+      end
+
+      schema = GrapeOAS.generate(app: api_class, schema_type: :oas2)
+      parameters = schema["paths"]["/accounts"]["get"]["parameters"]
+      role_param = parameters.find { |p| p["name"] == "role" }
+
+      assert_equal %w[admin user guest], role_param["enum"]
+      assert_equal "user", role_param["default"]
+    end
+
+    # === OAS3 ===
+
+    def test_oas3_string_param_with_default_exports_default
+      api_class = Class.new(Grape::API) do
+        format :json
+        params do
+          optional :status, type: String, default: "pending"
+        end
+        get "items" do
+          {}
+        end
+      end
+
+      schema = GrapeOAS.generate(app: api_class, schema_type: :oas3)
+      parameters = schema["paths"]["/items"]["get"]["parameters"]
+      status_param = parameters.find { |p| p["name"] == "status" }
+
+      assert_equal "pending", status_param["schema"]["default"]
+    end
+
+    def test_oas3_integer_param_with_default_exports_default
+      api_class = Class.new(Grape::API) do
+        format :json
+        params do
+          optional :page, type: Integer, default: 1
+        end
+        get "items" do
+          {}
+        end
+      end
+
+      schema = GrapeOAS.generate(app: api_class, schema_type: :oas3)
+      parameters = schema["paths"]["/items"]["get"]["parameters"]
+      page_param = parameters.find { |p| p["name"] == "page" }
+
+      assert_equal 1, page_param["schema"]["default"]
+    end
+
+    def test_oas3_boolean_param_with_false_default_exports_default
+      api_class = Class.new(Grape::API) do
+        format :json
+        params do
+          optional :enabled, type: Grape::API::Boolean, default: false
+        end
+        get "settings" do
+          {}
+        end
+      end
+
+      schema = GrapeOAS.generate(app: api_class, schema_type: :oas3)
+      parameters = schema["paths"]["/settings"]["get"]["parameters"]
+      enabled_param = parameters.find { |p| p["name"] == "enabled" }
+
+      # false is a valid default — it must be present (not absent/nil)
+      assert enabled_param["schema"].key?("default"), "expected 'default' key to be present in schema"
+      assert_equal false, enabled_param["schema"]["default"]
+    end
+
+    def test_oas3_param_with_default_and_enum_exports_both
+      api_class = Class.new(Grape::API) do
+        format :json
+        params do
+          optional :role, type: String, values: %w[admin user guest], default: "user"
+        end
+        get "accounts" do
+          {}
+        end
+      end
+
+      schema = GrapeOAS.generate(app: api_class, schema_type: :oas3)
+      parameters = schema["paths"]["/accounts"]["get"]["parameters"]
+      role_param = parameters.find { |p| p["name"] == "role" }
+
+      assert_equal %w[admin user guest], role_param["schema"]["enum"]
+      assert_equal "user", role_param["schema"]["default"]
+    end
+  end
+end

--- a/test/e2e/generate_default_value_test.rb
+++ b/test/e2e/generate_default_value_test.rb
@@ -82,6 +82,25 @@ module GrapeOAS
       assert_equal "user", role_param["default"]
     end
 
+    def test_oas2_body_param_with_default_exports_default
+      api_class = Class.new(Grape::API) do
+        format :json
+        params do
+          optional :name, type: String, default: "anonymous", documentation: { param_type: "body" }
+          optional :retries, type: Integer, default: 3, documentation: { param_type: "body" }
+        end
+        post "users" do
+          {}
+        end
+      end
+
+      schema = GrapeOAS.generate(app: api_class, schema_type: :oas2)
+      properties = schema["definitions"]["post_users_Request"]["properties"]
+
+      assert_equal "anonymous", properties["name"]["default"]
+      assert_equal 3, properties["retries"]["default"]
+    end
+
     # === OAS3 ===
 
     def test_oas3_string_param_with_default_exports_default
@@ -157,6 +176,25 @@ module GrapeOAS
 
       assert_equal %w[admin user guest], role_param["schema"]["enum"]
       assert_equal "user", role_param["schema"]["default"]
+    end
+
+    def test_oas3_body_param_with_default_exports_default
+      api_class = Class.new(Grape::API) do
+        format :json
+        params do
+          optional :name, type: String, default: "anonymous", documentation: { param_type: "body" }
+          optional :retries, type: Integer, default: 3, documentation: { param_type: "body" }
+        end
+        post "users" do
+          {}
+        end
+      end
+
+      schema = GrapeOAS.generate(app: api_class, schema_type: :oas3)
+      properties = schema["components"]["schemas"]["post_users_Request"]["properties"]
+
+      assert_equal "anonymous", properties["name"]["default"]
+      assert_equal 3, properties["retries"]["default"]
     end
   end
 end

--- a/test/e2e/generate_default_value_test.rb
+++ b/test/e2e/generate_default_value_test.rb
@@ -60,7 +60,7 @@ module GrapeOAS
 
       # false is a valid default — it must be present (not absent/nil)
       assert enabled_param.key?("default"), "expected 'default' key to be present"
-      assert_equal false, enabled_param["default"]
+      assert_equal false, enabled_param["default"] # rubocop:disable Minitest/RefuteFalse
     end
 
     def test_oas2_param_with_default_and_enum_exports_both
@@ -137,7 +137,7 @@ module GrapeOAS
 
       # false is a valid default — it must be present (not absent/nil)
       assert enabled_param["schema"].key?("default"), "expected 'default' key to be present in schema"
-      assert_equal false, enabled_param["schema"]["default"]
+      assert_equal false, enabled_param["schema"]["default"] # rubocop:disable Minitest/RefuteFalse
     end
 
     def test_oas3_param_with_default_and_enum_exports_both

--- a/test/grape_oas/api_model_builders/request_params_defaults_test.rb
+++ b/test/grape_oas/api_model_builders/request_params_defaults_test.rb
@@ -36,6 +36,8 @@ module GrapeOAS
         refute_nil disabled_param
         assert_equal "boolean", enabled_param.schema.type
         assert_equal "boolean", disabled_param.schema.type
+        assert_equal false, enabled_param.schema.default
+        assert_equal true, disabled_param.schema.default
       end
 
       # === Integer zero default ===
@@ -60,6 +62,7 @@ module GrapeOAS
 
         refute_nil count_param
         assert_equal "integer", count_param.schema.type
+        assert_equal 0, count_param.schema.default
       end
 
       # === String empty default ===
@@ -153,6 +156,7 @@ module GrapeOAS
 
         refute_nil status_param
         assert_equal "string", status_param.schema.type
+        assert_equal "pending", status_param.schema.default
       end
 
       # === Default in nested hash ===

--- a/test/grape_oas/api_model_builders/request_params_defaults_test.rb
+++ b/test/grape_oas/api_model_builders/request_params_defaults_test.rb
@@ -88,6 +88,8 @@ module GrapeOAS
 
         refute_nil prefix_param
         refute_nil suffix_param
+        assert_equal "", prefix_param.schema.default
+        assert_equal "default", suffix_param.schema.default
       end
 
       # === Array default ===
@@ -111,6 +113,7 @@ module GrapeOAS
 
         refute_nil tags
         assert_equal "array", tags.type
+        assert_equal %w[default], tags.default
       end
 
       # === Nil default (explicitly nil) ===
@@ -133,6 +136,7 @@ module GrapeOAS
         nullable_param = params.find { |p| p.name == "nullable_field" }
 
         refute_nil nullable_param
+        assert_nil nullable_param.schema.default
       end
 
       # === Default with enum values ===
@@ -185,6 +189,8 @@ module GrapeOAS
         assert_equal "object", config.type
         assert_includes config.properties.keys, "timeout"
         assert_includes config.properties.keys, "retries"
+        assert_equal 30, config.properties["timeout"].default
+        assert_equal 3, config.properties["retries"].default
       end
 
       # === Documentation default vs param default ===
@@ -208,7 +214,31 @@ module GrapeOAS
         value_param = params.find { |p| p.name == "value" }
 
         refute_nil value_param
-        # Just verify parameter exists - default source depends on implementation
+        # spec[:default] takes precedence over doc[:default]
+        assert_equal "param_default", value_param.schema.default
+      end
+
+      # === Documentation-only default ===
+
+      def test_documentation_only_default_applied
+        api_class = Class.new(Grape::API) do
+          format :json
+          params do
+            optional :value, type: String, documentation: { default: "doc_default" }
+          end
+          get "test" do
+            {}
+          end
+        end
+
+        route = api_class.routes.first
+        builder = RequestParams.new(api: @api, route: route)
+        _body_schema, params = builder.build
+
+        value_param = params.find { |p| p.name == "value" }
+
+        refute_nil value_param
+        assert_equal "doc_default", value_param.schema.default
       end
     end
   end

--- a/test/grape_oas/api_model_builders/request_params_defaults_test.rb
+++ b/test/grape_oas/api_model_builders/request_params_defaults_test.rb
@@ -36,8 +36,8 @@ module GrapeOAS
         refute_nil disabled_param
         assert_equal "boolean", enabled_param.schema.type
         assert_equal "boolean", disabled_param.schema.type
-        assert_equal false, enabled_param.schema.default
-        assert_equal true, disabled_param.schema.default
+        assert_equal false, enabled_param.schema.default # rubocop:disable Minitest/RefuteFalse
+        assert_equal true, disabled_param.schema.default # rubocop:disable Minitest/AssertTruthy
       end
 
       # === Integer zero default ===

--- a/test/grape_oas/exporter/oas2_parameter_test.rb
+++ b/test/grape_oas/exporter/oas2_parameter_test.rb
@@ -424,6 +424,91 @@ module GrapeOAS
         assert_equal [1, 2, 3], level_param["enum"]
       end
 
+      def test_string_parameter_with_default_emits_default
+        schema = ApiModel::Schema.new(type: "string")
+        schema.default = "pending"
+        param = ApiModel::Parameter.new(
+          location: "query",
+          name: "status",
+          schema: schema,
+          required: false,
+        )
+        operation = ApiModel::Operation.new(
+          http_method: "get",
+          parameters: [param],
+        )
+
+        result = OAS2::Parameter.new(operation).build
+
+        status_param = result.find { |p| p["name"] == "status" }
+
+        assert_equal "pending", status_param["default"]
+      end
+
+      def test_integer_parameter_with_zero_default_emits_default
+        schema = ApiModel::Schema.new(type: "integer")
+        schema.default = 0
+        param = ApiModel::Parameter.new(
+          location: "query",
+          name: "page",
+          schema: schema,
+          required: false,
+        )
+        operation = ApiModel::Operation.new(
+          http_method: "get",
+          parameters: [param],
+        )
+
+        result = OAS2::Parameter.new(operation).build
+
+        page_param = result.find { |p| p["name"] == "page" }
+
+        assert page_param.key?("default"), "expected 'default' key to be present"
+        assert_equal 0, page_param["default"]
+      end
+
+      def test_boolean_parameter_with_false_default_emits_default
+        schema = ApiModel::Schema.new(type: "boolean")
+        schema.default = false
+        param = ApiModel::Parameter.new(
+          location: "query",
+          name: "enabled",
+          schema: schema,
+          required: false,
+        )
+        operation = ApiModel::Operation.new(
+          http_method: "get",
+          parameters: [param],
+        )
+
+        result = OAS2::Parameter.new(operation).build
+
+        enabled_param = result.find { |p| p["name"] == "enabled" }
+
+        assert enabled_param.key?("default"), "expected 'default' key to be present"
+        assert_equal false, enabled_param["default"]
+      end
+
+      def test_parameter_without_default_does_not_emit_default_key
+        schema = ApiModel::Schema.new(type: "string")
+        param = ApiModel::Parameter.new(
+          location: "query",
+          name: "name",
+          schema: schema,
+          required: false,
+        )
+        operation = ApiModel::Operation.new(
+          http_method: "get",
+          parameters: [param],
+        )
+
+        result = OAS2::Parameter.new(operation).build
+
+        name_param = result.find { |p| p["name"] == "name" }
+
+        refute name_param.key?("default")
+      end
+
       def test_empty_enum_not_emitted
         schema = ApiModel::Schema.new(type: "string")
         schema.enum = []

--- a/test/grape_oas/exporter/oas2_parameter_test.rb
+++ b/test/grape_oas/exporter/oas2_parameter_test.rb
@@ -486,7 +486,7 @@ module GrapeOAS
         enabled_param = result.find { |p| p["name"] == "enabled" }
 
         assert enabled_param.key?("default"), "expected 'default' key to be present"
-        assert_equal false, enabled_param["default"]
+        assert_equal false, enabled_param["default"] # rubocop:disable Minitest/RefuteFalse
       end
 
       def test_parameter_without_default_does_not_emit_default_key

--- a/test/grape_oas/exporter/oas2_schema_test.rb
+++ b/test/grape_oas/exporter/oas2_schema_test.rb
@@ -258,6 +258,45 @@ module GrapeOAS
         assert result["items"]["allOf"], "allOf should be present on items"
       end
 
+      # === Default value tests ===
+
+      def test_schema_with_string_default_emits_default
+        schema = ApiModel::Schema.new(type: "string")
+        schema.default = "pending"
+
+        result = OAS2::Schema.new(schema).build
+
+        assert_equal "pending", result["default"]
+      end
+
+      def test_schema_with_integer_zero_default_emits_default
+        schema = ApiModel::Schema.new(type: "integer")
+        schema.default = 0
+
+        result = OAS2::Schema.new(schema).build
+
+        assert result.key?("default"), "expected 'default' key to be present"
+        assert_equal 0, result["default"]
+      end
+
+      def test_schema_with_false_default_emits_default
+        schema = ApiModel::Schema.new(type: "boolean")
+        schema.default = false
+
+        result = OAS2::Schema.new(schema).build
+
+        assert result.key?("default"), "expected 'default' key to be present"
+        assert_equal false, result["default"] # rubocop:disable Minitest/RefuteFalse
+      end
+
+      def test_schema_without_default_does_not_emit_default_key
+        schema = ApiModel::Schema.new(type: "string")
+
+        result = OAS2::Schema.new(schema).build
+
+        refute result.key?("default")
+      end
+
       # === Inline nested object with enum properties ===
 
       def test_inline_nested_object_with_enum_properties

--- a/test/grape_oas/exporter/oas3_schema_test.rb
+++ b/test/grape_oas/exporter/oas3_schema_test.rb
@@ -43,6 +43,43 @@ module GrapeOAS
         assert_equal 10, result["maxItems"]
       end
 
+      def test_schema_with_string_default_emits_default
+        schema = ApiModel::Schema.new(type: "string")
+        schema.default = "pending"
+
+        result = OAS3::Schema.new(schema).build
+
+        assert_equal "pending", result["default"]
+      end
+
+      def test_schema_with_integer_zero_default_emits_default
+        schema = ApiModel::Schema.new(type: "integer")
+        schema.default = 0
+
+        result = OAS3::Schema.new(schema).build
+
+        assert result.key?("default"), "expected 'default' key to be present"
+        assert_equal 0, result["default"]
+      end
+
+      def test_schema_with_false_default_emits_default
+        schema = ApiModel::Schema.new(type: "boolean")
+        schema.default = false
+
+        result = OAS3::Schema.new(schema).build
+
+        assert result.key?("default"), "expected 'default' key to be present"
+        assert_equal false, result["default"]
+      end
+
+      def test_schema_without_default_does_not_emit_default_key
+        schema = ApiModel::Schema.new(type: "string")
+
+        result = OAS3::Schema.new(schema).build
+
+        refute result.key?("default")
+      end
+
       def test_constraints_not_included_when_not_set
         schema = ApiModel::Schema.new(type: "string")
 

--- a/test/grape_oas/exporter/oas3_schema_test.rb
+++ b/test/grape_oas/exporter/oas3_schema_test.rb
@@ -69,7 +69,7 @@ module GrapeOAS
         result = OAS3::Schema.new(schema).build
 
         assert result.key?("default"), "expected 'default' key to be present"
-        assert_equal false, result["default"]
+        assert_equal false, result["default"] # rubocop:disable Minitest/RefuteFalse
       end
 
       def test_schema_without_default_does_not_emit_default_key


### PR DESCRIPTION
## Summary

Grape allows declaring default values for optional parameters, but these values
were silently dropped during OAS export. This PR threads `default` through the
full pipeline — schema model, builder, and both OAS2/OAS3 exporters — so the
generated spec accurately reflects the API contract.

- Add `default` to `Schema::VALID_ATTRIBUTES` and extract it in `SchemaEnhancer.apply_default`
  with spec-over-doc priority (param `default:` wins over `documentation: { default: }`)
- Emit `"default"` in OAS2 parameter, OAS2 schema, and OAS3 schema exporters,
  using `nil?` guard to correctly preserve falsy values (`false`, `0`)
- Cover all exporter paths with unit tests (OAS2 parameter, OAS2 schema, OAS3 schema),
  builder-level tests (empty string, array, nil, nested hash, priority), and e2e tests
  for both query and body parameters across OAS2 and OAS3

## Example

```ruby
# Grape endpoint with default values:
params do
  optional :status, type: String, default: "pending"
  optional :enabled, type: Grape::API::Boolean, default: false
  optional :page, type: Integer, default: 1
end
get "items" do
  {}
end

# Before (defaults silently dropped):
# { "name": "status", "type": "string", "in": "query" }

# After (defaults included in OAS output):
# { "name": "status", "type": "string", "in": "query", "default": "pending" }
# { "name": "enabled", "type": "boolean", "in": "query", "default": false }
# { "name": "page", "type": "integer", "in": "query", "default": 1 }
```

Falsy defaults (`false`, `0`) are correctly preserved — they are not treated as absent.