### PR TITLE
Fix Dangerfile to properly look for tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#60](https://github.com/numbata/grape-oas/pull/60): Fix `Dangerfile` to properly look for tests - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#58](https://github.com/numbata/grape-oas/pull/58): Fix contract extraction compatibility with Grape 3.2 - [@numbata](https://github.com/numbata).
 - [#57](https://github.com/numbata/grape-oas/pull/57): Fix `Array<Array<...>>` double-wrap when `is_array: true` is used with typed array notation like `type: [String]` — the redundant `is_array` flag no longer produces a nested array schema - [@numbata](https://github.com/numbata).
 - Your contribution here

--- a/Dangerfile
+++ b/Dangerfile
@@ -6,17 +6,17 @@ danger.import_dangerfile(gem: 'danger-pr-comment')
 # Has any changes happened inside the actual library code?
 # --------------------------------------------------------------------------------------------------------------------
 has_app_changes = !git.modified_files.grep(/lib/).empty?
-has_spec_changes = !git.modified_files.grep(/spec/).empty?
+has_test_changes = !git.modified_files.grep(/test/).empty?
 
 # --------------------------------------------------------------------------------------------------------------------
 # You've made changes to lib, but didn't write any tests?
 # --------------------------------------------------------------------------------------------------------------------
-warn("There're library changes, but not tests. That's OK as long as you're refactoring existing code.", sticky: false) if has_app_changes && !has_spec_changes
+warn("There're library changes, but not tests. That's OK as long as you're refactoring existing code.", sticky: false) if has_app_changes && !has_test_changes
 
 # --------------------------------------------------------------------------------------------------------------------
-# You've made changes to specs, but no library code has changed?
+# You've made changes to tests, but no library code has changed?
 # --------------------------------------------------------------------------------------------------------------------
-if !has_app_changes && has_spec_changes
+if !has_app_changes && has_test_changes
   message('We really appreciate pull requests that demonstrate issues, even without a fix. That said, the next step is to try and fix the failing tests!', sticky: false)
 end
 


### PR DESCRIPTION
The Dangerfile was configured to look for tests in `spec/`, but this gem uses `test/` for tests.