### PR TITLE
Respect `entity_name` on `Grape::Entity` subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#58](https://github.com/numbata/grape-oas/pull/58): Fix contract extraction compatibility with Grape 3.2 - [@numbata](https://github.com/numbata).
 - [#57](https://github.com/numbata/grape-oas/pull/57): Fix `Array<Array<...>>` double-wrap when `is_array: true` is used with typed array notation like `type: [String]` — the redundant `is_array` flag no longer produces a nested array schema - [@numbata](https://github.com/numbata).
 - [#59](https://github.com/numbata/grape-oas/pull/59): Export `default` param values to OAS2 and OAS3 output - [@olivier-thatch](https://github.com/olivier-thatch).
+- [#61](https://github.com/numbata/grape-oas/pull/61): Respect `entity_name` on `grape::entity` subclasses - [@olivier-thatch](https://github.com/olivier-thatch).
 - Your contribution here
 
 ## [1.3.0] - 2026-03-27

--- a/lib/grape_oas/introspectors/entity_introspector.rb
+++ b/lib/grape_oas/introspectors/entity_introspector.rb
@@ -88,10 +88,18 @@ module GrapeOAS
       def initialize_or_reuse_schema
         @registry[@entity_class] ||= ApiModel::Schema.new(
           type: Constants::SchemaTypes::OBJECT,
-          canonical_name: @entity_class.name,
+          canonical_name: resolve_canonical_name,
           description: nil,
           nullable: nil,
         )
+      end
+
+      def resolve_canonical_name
+        if @entity_class.respond_to?(:entity_name)
+          @entity_class.entity_name
+        else
+          @entity_class.name
+        end
       end
 
       def populate_schema(schema)

--- a/lib/grape_oas/introspectors/entity_introspector.rb
+++ b/lib/grape_oas/introspectors/entity_introspector.rb
@@ -95,11 +95,7 @@ module GrapeOAS
       end
 
       def resolve_canonical_name
-        if @entity_class.respond_to?(:entity_name)
-          @entity_class.entity_name
-        else
-          @entity_class.name
-        end
+        EntityIntrospectorSupport.resolve_canonical_name(@entity_class)
       end
 
       def populate_schema(schema)

--- a/lib/grape_oas/introspectors/entity_introspector_support.rb
+++ b/lib/grape_oas/introspectors/entity_introspector_support.rb
@@ -20,11 +20,14 @@ module GrapeOAS
       end
 
       # Resolves the canonical name for an entity class, preferring entity_name
-      # when defined and non-empty, falling back to the Ruby class name.
+      # when defined directly on the class and non-blank, falling back to the
+      # Ruby class name. Inherited entity_name is ignored to avoid collisions
+      # between parent and child schemas.
       def self.resolve_canonical_name(entity_class)
-        if entity_class.respond_to?(:entity_name)
+        if entity_class.respond_to?(:entity_name) &&
+           entity_class.method(:entity_name).owner == entity_class.singleton_class
           name = entity_class.entity_name
-          name && !name.empty? ? name : entity_class.name
+          name.is_a?(String) && !name.strip.empty? ? name : entity_class.name
         else
           entity_class.name
         end

--- a/lib/grape_oas/introspectors/entity_introspector_support.rb
+++ b/lib/grape_oas/introspectors/entity_introspector_support.rb
@@ -20,18 +20,28 @@ module GrapeOAS
       end
 
       # Resolves the canonical name for an entity class, preferring entity_name
-      # when defined directly on the class and non-blank, falling back to the
-      # Ruby class name. Inherited entity_name is ignored to avoid collisions
-      # between parent and child schemas.
+      # when defined on the class itself (via def self. or extend) and non-blank,
+      # falling back to the Ruby class name. Inherited entity_name is ignored to
+      # avoid collisions between parent and child schemas.
       def self.resolve_canonical_name(entity_class)
-        if entity_class.respond_to?(:entity_name) &&
-           entity_class.method(:entity_name).owner == entity_class.singleton_class
+        if defines_own_entity_name?(entity_class)
           name = entity_class.entity_name
           name.is_a?(String) && !name.strip.empty? ? name : entity_class.name
         else
           entity_class.name
         end
       end
+
+      def self.defines_own_entity_name?(entity_class)
+        return false unless entity_class.respond_to?(:entity_name)
+
+        parent = find_parent_entity(entity_class)
+        return true if parent.nil? || !parent.respond_to?(:entity_name)
+
+        entity_class.method(:entity_name).owner !=
+          parent.method(:entity_name).owner
+      end
+      private_class_method :defines_own_entity_name?
 
       # Finds the parent entity class if one exists in the Grape::Entity hierarchy.
       def self.find_parent_entity(entity_class)

--- a/lib/grape_oas/introspectors/entity_introspector_support.rb
+++ b/lib/grape_oas/introspectors/entity_introspector_support.rb
@@ -19,6 +19,17 @@ module GrapeOAS
         []
       end
 
+      # Resolves the canonical name for an entity class, preferring entity_name
+      # when defined and non-empty, falling back to the Ruby class name.
+      def self.resolve_canonical_name(entity_class)
+        if entity_class.respond_to?(:entity_name)
+          name = entity_class.entity_name
+          name && !name.empty? ? name : entity_class.name
+        else
+          entity_class.name
+        end
+      end
+
       # Finds the parent entity class if one exists in the Grape::Entity hierarchy.
       def self.find_parent_entity(entity_class)
         return nil unless defined?(Grape::Entity)

--- a/lib/grape_oas/introspectors/entity_introspector_support/inheritance_builder.rb
+++ b/lib/grape_oas/introspectors/entity_introspector_support/inheritance_builder.rb
@@ -41,7 +41,7 @@ module GrapeOAS
 
           # Create allOf schema with ref to parent + child properties
           schema = ApiModel::Schema.new(
-            canonical_name: @entity_class.name,
+            canonical_name: EntityIntrospectorSupport.resolve_canonical_name(@entity_class),
             all_of: [parent_schema, child_schema],
           )
 

--- a/test/e2e/generate_entity_name_test.rb
+++ b/test/e2e/generate_entity_name_test.rb
@@ -130,4 +130,212 @@ module GrapeOAS
       assert_equal "#/definitions/UserResponse", ref
     end
   end
+
+  # Tests that entity_name returning nil or empty string falls back to class name
+  class GenerateEntityNameEdgeCasesTest < Minitest::Test
+    class NilNameEntity < Grape::Entity
+      expose :id, documentation: { type: Integer }
+
+      def self.entity_name
+        nil
+      end
+    end
+
+    class EmptyNameEntity < Grape::Entity
+      expose :id, documentation: { type: Integer }
+
+      def self.entity_name
+        ""
+      end
+    end
+
+    class NilNameAPI < Grape::API
+      format :json
+
+      desc "Get item" do
+        success NilNameEntity
+      end
+      get "/nil-name" do
+        {}
+      end
+    end
+
+    class EmptyNameAPI < Grape::API
+      format :json
+
+      desc "Get item" do
+        success EmptyNameEntity
+      end
+      get "/empty-name" do
+        {}
+      end
+    end
+
+    # entity_name returning nil should fall back to class name, not produce nil canonical_name
+    def test_oas3_nil_entity_name_falls_back_to_class_name
+      schema = GrapeOAS.generate(app: NilNameAPI, schema_type: :oas3)
+      schemas = schema.dig("components", "schemas")
+
+      assert schemas, "Expected components/schemas to be present"
+      refute schemas.key?(""), "Schema key should not be empty string"
+      refute schemas.keys.any?(&:nil?), "Schema key should not be nil"
+
+      # Should fall back to mangled class name
+      nil_name_key = schemas.keys.find { |k| k.include?("NilName") }
+
+      assert nil_name_key, "Expected a schema key derived from class name for NilNameEntity"
+    end
+
+    # entity_name returning empty string should fall back to class name
+    def test_oas3_empty_entity_name_falls_back_to_class_name
+      schema = GrapeOAS.generate(app: EmptyNameAPI, schema_type: :oas3)
+      schemas = schema.dig("components", "schemas")
+
+      assert schemas, "Expected components/schemas to be present"
+      refute schemas.key?(""), "Schema key should not be empty string"
+
+      empty_name_key = schemas.keys.find { |k| k.include?("EmptyName") }
+
+      assert empty_name_key, "Expected a schema key derived from class name for EmptyNameEntity"
+    end
+
+    # OAS3: $ref should not point to empty schema name
+    def test_oas3_empty_entity_name_ref_is_valid
+      schema = GrapeOAS.generate(app: EmptyNameAPI, schema_type: :oas3)
+      response_schema = schema.dig(
+        "paths", "/empty-name", "get", "responses", "200", "content", "application/json", "schema",
+      )
+
+      assert response_schema, "Expected response schema to be present"
+      ref = response_schema["$ref"] || response_schema.dig("allOf", 0, "$ref")
+
+      assert ref, "Expected a $ref in the response schema"
+      refute_equal "#/components/schemas/", ref, "$ref must not point to empty schema name"
+    end
+  end
+
+  # Tests that entity_name is respected on child entities in inheritance hierarchies
+  class GenerateEntityNameInheritanceTest < Minitest::Test
+    class AnimalEntity < Grape::Entity
+      expose :species, documentation: {
+        type: String,
+        is_discriminator: true,
+        required: true
+      }
+      expose :name, documentation: { type: String }
+
+      def self.entity_name
+        "Animal"
+      end
+    end
+
+    class CatEntity < AnimalEntity
+      expose :indoor, documentation: { type: "Boolean" }
+
+      def self.entity_name
+        "Cat"
+      end
+    end
+
+    class DogEntity < AnimalEntity
+      expose :breed, documentation: { type: String }
+    end
+
+    class InheritanceAPI < Grape::API
+      format :json
+
+      desc "Get animal" do
+        success AnimalEntity
+      end
+      get "/animals/:id" do
+        {}
+      end
+
+      desc "Get cat" do
+        success CatEntity
+      end
+      get "/cats/:id" do
+        {}
+      end
+
+      desc "Get dog" do
+        success DogEntity
+      end
+      get "/dogs/:id" do
+        {}
+      end
+    end
+
+    # Child entity with entity_name should use it as schema key, not class name
+    def test_oas3_child_entity_uses_entity_name_as_schema_key
+      schema = GrapeOAS.generate(app: InheritanceAPI, schema_type: :oas3)
+      schemas = schema.dig("components", "schemas")
+
+      assert schemas, "Expected components/schemas to be present"
+      assert_includes schemas.keys, "Cat",
+                      "Expected schema key 'Cat' from entity_name, got: #{schemas.keys.inspect}"
+    end
+
+    # Parent entity with entity_name should use it as schema key
+    def test_oas3_parent_entity_uses_entity_name_as_schema_key
+      schema = GrapeOAS.generate(app: InheritanceAPI, schema_type: :oas3)
+      schemas = schema.dig("components", "schemas")
+
+      assert_includes schemas.keys, "Animal",
+                      "Expected schema key 'Animal' from entity_name, got: #{schemas.keys.inspect}"
+    end
+
+    # allOf $ref in child should point to parent's entity_name
+    def test_oas3_child_allof_ref_uses_parent_entity_name
+      schema = GrapeOAS.generate(app: InheritanceAPI, schema_type: :oas3)
+      schemas = schema.dig("components", "schemas")
+
+      cat_schema = schemas["Cat"]
+
+      assert cat_schema, "Expected 'Cat' schema to exist"
+
+      all_of = cat_schema["allOf"]
+
+      assert all_of, "Expected Cat to use allOf for inheritance"
+      assert_equal "#/components/schemas/Animal", all_of[0]["$ref"],
+                   "allOf $ref should point to parent's entity_name 'Animal'"
+    end
+
+    # Child without entity_name should still use class name in inheritance
+    def test_oas3_child_without_entity_name_uses_class_name
+      schema = GrapeOAS.generate(app: InheritanceAPI, schema_type: :oas3)
+      schemas = schema.dig("components", "schemas")
+
+      dog_key = schemas.keys.find { |k| k.include?("Dog") }
+
+      assert dog_key, "Expected a schema key for DogEntity"
+      # DogEntity has no entity_name, so it should fall back to class name
+      refute_equal "Dog", dog_key, "Without entity_name, should use mangled class name"
+    end
+
+    # OAS2: same behavior for inheritance with entity_name
+    def test_oas2_child_entity_uses_entity_name_as_definition_key
+      schema = GrapeOAS.generate(app: InheritanceAPI, schema_type: :oas2)
+      definitions = schema["definitions"]
+
+      assert definitions, "Expected definitions to be present"
+      assert_includes definitions.keys, "Cat",
+                      "Expected definition key 'Cat' from entity_name, got: #{definitions.keys.inspect}"
+    end
+
+    def test_oas2_child_allof_ref_uses_parent_entity_name
+      schema = GrapeOAS.generate(app: InheritanceAPI, schema_type: :oas2)
+      definitions = schema["definitions"]
+
+      cat_schema = definitions["Cat"]
+
+      assert cat_schema, "Expected 'Cat' definition to exist"
+
+      all_of = cat_schema["allOf"]
+
+      assert all_of, "Expected Cat to use allOf for inheritance"
+      assert_equal "#/definitions/Animal", all_of[0]["$ref"],
+                   "allOf $ref should point to parent's entity_name 'Animal'"
+    end
+  end
 end

--- a/test/e2e/generate_entity_name_test.rb
+++ b/test/e2e/generate_entity_name_test.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GrapeOAS
+  # Tests that grape-oas respects the entity_name method optionally defined on
+  # Grape::Entity subclasses. When present, entity_name should be used as the
+  # schema definition key (and $ref target) instead of the mangled Ruby class name.
+  class GenerateEntityNameTest < Minitest::Test
+    class UserEntity < Grape::Entity
+      expose :id, documentation: { type: Integer, desc: "User ID" }
+      expose :name, documentation: { type: String, desc: "Full name" }
+
+      def self.entity_name
+        "UserResponse"
+      end
+    end
+
+    class PostEntity < Grape::Entity
+      expose :id, documentation: { type: Integer }
+      expose :title, documentation: { type: String }
+      expose :author, using: UserEntity, documentation: { type: UserEntity }
+    end
+
+    class SampleAPI < Grape::API
+      format :json
+
+      desc "Get a user" do
+        success UserEntity
+      end
+      get "/users/:id" do
+        {}
+      end
+
+      desc "Get a post" do
+        success PostEntity
+      end
+      get "/posts/:id" do
+        {}
+      end
+
+      desc "List users" do
+        success UserEntity
+        detail "Returns array of users"
+      end
+      get "/users" do
+        {}
+      end
+    end
+
+    # OAS3: schema key in components/schemas should be the entity_name value
+    def test_oas3_uses_entity_name_as_schema_key
+      schema = GrapeOAS.generate(app: SampleAPI, schema_type: :oas3)
+      schemas = schema.dig("components", "schemas")
+
+      assert schemas, "Expected components/schemas to be present"
+      assert_includes schemas.keys, "UserResponse",
+                      "Expected schema key 'UserResponse' from entity_name, got: #{schemas.keys.inspect}"
+      refute_includes schemas.keys, "GrapeOAS_GenerateEntityNameTest_UserEntity",
+                      "Schema key should not be the mangled Ruby class name"
+    end
+
+    # OAS3: $ref in response should point to the entity_name
+    def test_oas3_ref_uses_entity_name
+      schema = GrapeOAS.generate(app: SampleAPI, schema_type: :oas3)
+      response_schema = schema.dig(
+        "paths", "/users/{id}", "get", "responses", "200", "content", "application/json", "schema",
+      )
+
+      assert response_schema, "Expected response schema to be present"
+      ref = response_schema["$ref"] || response_schema.dig("allOf", 0, "$ref")
+
+      assert ref, "Expected a $ref in the response schema, got: #{response_schema.inspect}"
+      assert_equal "#/components/schemas/UserResponse", ref
+    end
+
+    # OAS3: entity without entity_name should still use the mangled class name
+    def test_oas3_entity_without_entity_name_uses_class_name
+      schema = GrapeOAS.generate(app: SampleAPI, schema_type: :oas3)
+      schemas = schema.dig("components", "schemas")
+
+      assert schemas, "Expected components/schemas to be present"
+      post_key = schemas.keys.find { |k| k.include?("Post") }
+
+      assert post_key, "Expected a schema key for PostEntity"
+      refute_equal "PostEntity", post_key, "Unqualified class name is not expected as-is"
+    end
+
+    # OAS3: nested reference (PostEntity referencing UserEntity) should also use entity_name
+    def test_oas3_nested_ref_uses_entity_name
+      schema = GrapeOAS.generate(app: SampleAPI, schema_type: :oas3)
+      schemas = schema.dig("components", "schemas")
+
+      post_key = schemas.keys.find { |k| k.include?("Post") }
+
+      assert post_key, "Expected a schema key for PostEntity"
+
+      author_prop = schemas.dig(post_key, "properties", "author")
+
+      assert author_prop, "Expected 'author' property in PostEntity schema"
+
+      ref = author_prop["$ref"] || author_prop.dig("allOf", 0, "$ref")
+
+      assert ref, "Expected a $ref for author property, got: #{author_prop.inspect}"
+      assert_equal "#/components/schemas/UserResponse", ref,
+                   "Nested $ref should use entity_name 'UserResponse'"
+    end
+
+    # OAS2: schema key in definitions should be the entity_name value
+    def test_oas2_uses_entity_name_as_definition_key
+      schema = GrapeOAS.generate(app: SampleAPI, schema_type: :oas2)
+      definitions = schema["definitions"]
+
+      assert definitions, "Expected definitions to be present"
+      assert_includes definitions.keys, "UserResponse",
+                      "Expected definition key 'UserResponse' from entity_name, got: #{definitions.keys.inspect}"
+      refute_includes definitions.keys, "GrapeOAS_GenerateEntityNameTest_UserEntity",
+                      "Definition key should not be the mangled Ruby class name"
+    end
+
+    # OAS2: $ref in response should point to the entity_name
+    def test_oas2_ref_uses_entity_name
+      schema = GrapeOAS.generate(app: SampleAPI, schema_type: :oas2)
+      response_schema = schema.dig("paths", "/users/{id}", "get", "responses", "200", "schema")
+
+      assert response_schema, "Expected response schema to be present"
+      ref = response_schema["$ref"] || response_schema.dig("allOf", 0, "$ref")
+
+      assert ref, "Expected a $ref in the response schema, got: #{response_schema.inspect}"
+      assert_equal "#/definitions/UserResponse", ref
+    end
+  end
+end

--- a/test/e2e/generate_entity_name_test.rb
+++ b/test/e2e/generate_entity_name_test.rb
@@ -301,19 +301,27 @@ module GrapeOAS
                    "allOf $ref should point to parent's entity_name 'Animal'"
     end
 
-    # Child without its own entity_name inherits parent's entity_name via Ruby
-    # class method inheritance, so its schema key matches the parent's.
-    # This verifies the child schema still exists (registered under inherited name).
-    def test_oas3_child_without_entity_name_inherits_parent_name
+    # Child without its own entity_name falls back to class name and gets
+    # its own schema with child-specific properties preserved.
+    def test_oas3_child_without_entity_name_uses_class_name
       schema = GrapeOAS.generate(app: InheritanceAPI, schema_type: :oas3)
-      response_schema = schema.dig(
-        "paths", "/dogs/{id}", "get", "responses", "200", "content", "application/json", "schema",
-      )
+      schemas = schema.dig("components", "schemas")
 
-      assert response_schema, "Expected response schema for dogs endpoint"
-      ref = response_schema["$ref"] || response_schema.dig("allOf", 0, "$ref")
+      dog_key = schemas.keys.find { |k| k.include?("Dog") }
 
-      assert ref, "Expected a $ref in dogs response"
+      assert dog_key, "Expected a schema key for DogEntity"
+      refute_equal "Animal", dog_key,
+                   "Child without own entity_name must not collide with parent"
+
+      dog_schema = schemas[dog_key]
+      all_of = dog_schema["allOf"]
+
+      assert all_of, "Expected DogEntity to use allOf for inheritance"
+      assert_equal "#/components/schemas/Animal", all_of[0]["$ref"]
+
+      child_props = all_of[1]["properties"]
+
+      assert child_props&.key?("breed"), "DogEntity's own 'breed' property must be present"
     end
 
     # OAS2: same behavior for inheritance with entity_name

--- a/test/e2e/generate_entity_name_test.rb
+++ b/test/e2e/generate_entity_name_test.rb
@@ -301,16 +301,19 @@ module GrapeOAS
                    "allOf $ref should point to parent's entity_name 'Animal'"
     end
 
-    # Child without entity_name should still use class name in inheritance
-    def test_oas3_child_without_entity_name_uses_class_name
+    # Child without its own entity_name inherits parent's entity_name via Ruby
+    # class method inheritance, so its schema key matches the parent's.
+    # This verifies the child schema still exists (registered under inherited name).
+    def test_oas3_child_without_entity_name_inherits_parent_name
       schema = GrapeOAS.generate(app: InheritanceAPI, schema_type: :oas3)
-      schemas = schema.dig("components", "schemas")
+      response_schema = schema.dig(
+        "paths", "/dogs/{id}", "get", "responses", "200", "content", "application/json", "schema",
+      )
 
-      dog_key = schemas.keys.find { |k| k.include?("Dog") }
+      assert response_schema, "Expected response schema for dogs endpoint"
+      ref = response_schema["$ref"] || response_schema.dig("allOf", 0, "$ref")
 
-      assert dog_key, "Expected a schema key for DogEntity"
-      # DogEntity has no entity_name, so it should fall back to class name
-      refute_equal "Dog", dog_key, "Without entity_name, should use mangled class name"
+      assert ref, "Expected a $ref in dogs response"
     end
 
     # OAS2: same behavior for inheritance with entity_name

--- a/test/grape_oas/introspectors/entity_introspector_support/resolve_canonical_name_test.rb
+++ b/test/grape_oas/introspectors/entity_introspector_support/resolve_canonical_name_test.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GrapeOAS
+  module Introspectors
+    module EntityIntrospectorSupport
+      class ResolveCanonicalNameTest < Minitest::Test
+        class PlainEntity < Grape::Entity
+          expose :id, documentation: { type: Integer }
+        end
+
+        class NamedEntity < Grape::Entity
+          expose :id, documentation: { type: Integer }
+
+          def self.entity_name
+            "CustomName"
+          end
+        end
+
+        class NilNameEntity < Grape::Entity
+          expose :id, documentation: { type: Integer }
+
+          def self.entity_name
+            nil
+          end
+        end
+
+        class EmptyNameEntity < Grape::Entity
+          expose :id, documentation: { type: Integer }
+
+          def self.entity_name
+            ""
+          end
+        end
+
+        class WhitespaceNameEntity < Grape::Entity
+          expose :id, documentation: { type: Integer }
+
+          def self.entity_name
+            "   "
+          end
+        end
+
+        class ParentWithName < Grape::Entity
+          expose :id, documentation: { type: Integer }
+
+          def self.entity_name
+            "Parent"
+          end
+        end
+
+        class ChildInheritsName < ParentWithName
+          expose :extra, documentation: { type: String }
+        end
+
+        class ChildOverridesName < ParentWithName
+          expose :extra, documentation: { type: String }
+
+          def self.entity_name
+            "OverriddenChild"
+          end
+        end
+
+        def test_uses_class_name_when_no_entity_name
+          assert_equal PlainEntity.name,
+                       EntityIntrospectorSupport.resolve_canonical_name(PlainEntity)
+        end
+
+        def test_uses_entity_name_when_defined
+          assert_equal "CustomName",
+                       EntityIntrospectorSupport.resolve_canonical_name(NamedEntity)
+        end
+
+        def test_falls_back_on_nil_entity_name
+          assert_equal NilNameEntity.name,
+                       EntityIntrospectorSupport.resolve_canonical_name(NilNameEntity)
+        end
+
+        def test_falls_back_on_empty_entity_name
+          assert_equal EmptyNameEntity.name,
+                       EntityIntrospectorSupport.resolve_canonical_name(EmptyNameEntity)
+        end
+
+        def test_falls_back_on_whitespace_only_entity_name
+          assert_equal WhitespaceNameEntity.name,
+                       EntityIntrospectorSupport.resolve_canonical_name(WhitespaceNameEntity)
+        end
+
+        def test_ignores_inherited_entity_name
+          assert_equal ChildInheritsName.name,
+                       EntityIntrospectorSupport.resolve_canonical_name(ChildInheritsName)
+        end
+
+        def test_uses_overridden_entity_name
+          assert_equal "OverriddenChild",
+                       EntityIntrospectorSupport.resolve_canonical_name(ChildOverridesName)
+        end
+      end
+    end
+  end
+end

--- a/test/grape_oas/introspectors/entity_introspector_support/resolve_canonical_name_test.rb
+++ b/test/grape_oas/introspectors/entity_introspector_support/resolve_canonical_name_test.rb
@@ -62,6 +62,30 @@ module GrapeOAS
           end
         end
 
+        module EntityNaming
+          def entity_name
+            "FromModule"
+          end
+        end
+
+        class ExtendedEntity < Grape::Entity
+          extend EntityNaming
+
+          expose :id, documentation: { type: Integer }
+        end
+
+        class ChildInheritsExtend < ExtendedEntity
+          expose :extra, documentation: { type: String }
+        end
+
+        class ChildOverridesExtend < ExtendedEntity
+          expose :extra, documentation: { type: String }
+
+          def self.entity_name
+            "ChildOverride"
+          end
+        end
+
         def test_uses_class_name_when_no_entity_name
           assert_equal PlainEntity.name,
                        EntityIntrospectorSupport.resolve_canonical_name(PlainEntity)
@@ -95,6 +119,21 @@ module GrapeOAS
         def test_uses_overridden_entity_name
           assert_equal "OverriddenChild",
                        EntityIntrospectorSupport.resolve_canonical_name(ChildOverridesName)
+        end
+
+        def test_uses_entity_name_from_extend
+          assert_equal "FromModule",
+                       EntityIntrospectorSupport.resolve_canonical_name(ExtendedEntity)
+        end
+
+        def test_ignores_inherited_extend_entity_name
+          assert_equal ChildInheritsExtend.name,
+                       EntityIntrospectorSupport.resolve_canonical_name(ChildInheritsExtend)
+        end
+
+        def test_uses_overridden_extend_entity_name
+          assert_equal "ChildOverride",
+                       EntityIntrospectorSupport.resolve_canonical_name(ChildOverridesExtend)
         end
       end
     end


### PR DESCRIPTION
## Summary

Grape::Entity subclasses can define an `entity_name` class method to control
the schema name used in the generated OpenAPI spec. Without this, grape-oas
derives the schema key from the Ruby class name (e.g. `API_V1_Entities_UserEntity`),
which is often long and leaks internal namespace structure into the public API
documentation.

- Add `resolve_canonical_name` to `EntityIntrospectorSupport` as a shared method
  used by both `EntityIntrospector` and `InheritanceBuilder`
- Only use `entity_name` when defined directly on the class (via `def self.` or
  `extend`); inherited definitions are ignored to prevent parent and child schemas
  from colliding under the same key
- Fall back to the Ruby class name when `entity_name` returns nil, empty string,
  or whitespace-only value
- Works with discriminator-based inheritance (`allOf`): child entities with their
  own `entity_name` get a clean schema key while `$ref` to the parent uses the
  parent's `entity_name`

## Example

```ruby
class UserEntity < Grape::Entity
  expose :id, documentation: { type: Integer }
  expose :name, documentation: { type: String }

  def self.entity_name
    "User"
  end
end

class PostEntity < Grape::Entity
  expose :id, documentation: { type: Integer }
  expose :author, using: UserEntity, documentation: { type: UserEntity }
end
```

```yaml
# Before (mangled Ruby class name leaked into spec):
components:
  schemas:
    API_V1_Entities_UserEntity:
      type: object
      properties:
        id: { type: integer }
        name: { type: string }
    API_V1_Entities_PostEntity:
      type: object
      properties:
        author:
          $ref: "#/components/schemas/API_V1_Entities_UserEntity"

# After (clean schema name from entity_name):
components:
  schemas:
    User:
      type: object
      properties:
        id: { type: integer }
        name: { type: string }
    API_V1_Entities_PostEntity:
      type: object
      properties:
        author:
          $ref: "#/components/schemas/User"
```

Entities without `entity_name` continue to use the mangled class name — no breaking change.