### PR TITLE
Default to body params for POST/PUT/PATCH routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [#64](https://github.com/numbata/grape-oas/pull/64): Memoize content-type and default-format resolution per generation — eliminates redundant calls that scaled with route × response count - [@JuniorJoanis](https://github.com/JuniorJoanis).
+- [#62](https://github.com/numbata/grape-oas/pull/62): Default to body params for post/put/patch routes - [@olivier-thatch](https://github.com/olivier-thatch).
 - Your contribution here
 
 ## [1.3.0] - 2026-03-27

--- a/lib/grape_oas/api_model_builders/request_params_support/param_location_resolver.rb
+++ b/lib/grape_oas/api_model_builders/request_params_support/param_location_resolver.rb
@@ -65,7 +65,7 @@ module GrapeOAS
           # Precedence (highest to lowest):
           #   1. `param_type` option (e.g., `documentation: { param_type: 'query' }`)
           #   2. `in` option (e.g., `documentation: { in: 'query' }`)
-          #   3. Falls back to "query" if neither is specified
+          #   3. Defaults to "body" for write methods (POST/PUT/PATCH), "query" for read methods
           #
           # Note: If both `param_type` and `in` are specified, `param_type` takes precedence.
           # For example, `{ param_type: 'query', in: 'body' }` will be treated as query.

--- a/lib/grape_oas/api_model_builders/request_params_support/param_location_resolver.rb
+++ b/lib/grape_oas/api_model_builders/request_params_support/param_location_resolver.rb
@@ -81,7 +81,12 @@ module GrapeOAS
 
             # Support both param_type and in for grape-swagger compatibility
             # param_type takes precedence over in when both are specified
-            (param_type || in_location)&.to_s&.downcase || "query"
+            explicit_location = (param_type || in_location)&.to_s&.downcase
+            return explicit_location if explicit_location
+
+            # Default: body for write methods (POST/PUT/PATCH), query for read methods (GET/DELETE/HEAD)
+            http_method = route.request_method.to_s.downcase
+            Constants::HttpMethods::BODYLESS_HTTP_METHODS.include?(http_method) ? "query" : "body"
           end
         end
       end

--- a/test/e2e/generate_body_params_test.rb
+++ b/test/e2e/generate_body_params_test.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GrapeOAS
+  # Tests that flat params mixed with nested Hash params on POST routes
+  # all end up in the request body (OAS3: requestBody, OAS2: body parameter),
+  # and that flat params like :name are not silently dropped when a sibling
+  # Hash param causes the nested-params code path to activate.
+  class GenerateBodyParamsTest < Minitest::Test
+    class SampleAPI < Grape::API
+      format :json
+
+      namespace :users do
+        desc "Create user"
+        params do
+          requires :name, type: String
+          requires :address, type: Hash do
+            requires :city, type: String
+          end
+        end
+        post do
+          {}
+        end
+      end
+    end
+
+    # ---- OAS3 -------------------------------------------------------
+
+    def test_oas3_flat_string_param_appears_in_request_body
+      schema = GrapeOAS.generate(app: SampleAPI, schema_type: :oas3)
+      ref = schema.dig("paths", "/users", "post", "requestBody", "content", "application/json", "schema", "$ref")
+      props = schema.dig(*ref.delete_prefix("#/").split("/"), "properties")
+
+      assert_includes props.keys, "name", ":name must not be dropped from the OAS3 requestBody"
+      assert_equal "string", props["name"]["type"]
+    end
+
+    def test_oas3_nested_hash_param_appears_in_request_body
+      schema = GrapeOAS.generate(app: SampleAPI, schema_type: :oas3)
+      ref = schema.dig("paths", "/users", "post", "requestBody", "content", "application/json", "schema", "$ref")
+      props = schema.dig(*ref.delete_prefix("#/").split("/"), "properties")
+
+      assert_includes props.keys, "address", ":address must appear in the OAS3 requestBody"
+    end
+
+    def test_oas3_nested_hash_has_child_properties
+      schema = GrapeOAS.generate(app: SampleAPI, schema_type: :oas3)
+      ref = schema.dig("paths", "/users", "post", "requestBody", "content", "application/json", "schema", "$ref")
+      address = schema.dig(*ref.delete_prefix("#/").split("/"), "properties", "address")
+
+      assert_equal "object", address["type"]
+      assert_includes address["properties"].keys, "city"
+      assert_equal "string", address["properties"]["city"]["type"]
+    end
+
+    def test_oas3_required_fields_include_name_and_address
+      schema = GrapeOAS.generate(app: SampleAPI, schema_type: :oas3)
+      ref = schema.dig("paths", "/users", "post", "requestBody", "content", "application/json", "schema", "$ref")
+      required = schema.dig(*ref.delete_prefix("#/").split("/"), "required") || []
+
+      assert_includes required, "name"
+      assert_includes required, "address"
+    end
+
+    def test_oas3_no_spurious_query_params
+      schema = GrapeOAS.generate(app: SampleAPI, schema_type: :oas3)
+      names = (schema.dig("paths", "/users", "post", "parameters") || []).map { |p| p["name"] }
+
+      refute_includes names, "name", ":name must not appear as a query/path param in OAS3"
+      refute_includes names, "address", ":address must not appear as a query/path param in OAS3"
+    end
+
+    # ---- OAS2 -------------------------------------------------------
+
+    def test_oas2_flat_string_param_appears_in_body
+      schema = GrapeOAS.generate(app: SampleAPI, schema_type: :oas2)
+      body_param = schema.dig("paths", "/users", "post", "parameters").find { |p| p["in"] == "body" }
+      ref = body_param.dig("schema", "$ref")
+      props = schema.dig(*ref.delete_prefix("#/").split("/"), "properties")
+
+      assert_includes props.keys, "name", ":name must not be dropped from the OAS2 body parameter"
+      assert_equal "string", props["name"]["type"]
+    end
+
+    def test_oas2_nested_hash_param_appears_in_body
+      schema = GrapeOAS.generate(app: SampleAPI, schema_type: :oas2)
+      body_param = schema.dig("paths", "/users", "post", "parameters").find { |p| p["in"] == "body" }
+      ref = body_param.dig("schema", "$ref")
+      props = schema.dig(*ref.delete_prefix("#/").split("/"), "properties")
+
+      assert_includes props.keys, "address", ":address must appear in the OAS2 body parameter"
+    end
+
+    def test_oas2_nested_hash_has_child_properties
+      schema = GrapeOAS.generate(app: SampleAPI, schema_type: :oas2)
+      body_param = schema.dig("paths", "/users", "post", "parameters").find { |p| p["in"] == "body" }
+      ref = body_param.dig("schema", "$ref")
+      address = schema.dig(*ref.delete_prefix("#/").split("/"), "properties", "address")
+
+      assert_equal "object", address["type"]
+      assert_includes address["properties"].keys, "city"
+      assert_equal "string", address["properties"]["city"]["type"]
+    end
+
+    def test_oas2_no_spurious_query_params
+      schema = GrapeOAS.generate(app: SampleAPI, schema_type: :oas2)
+      non_body = schema.dig("paths", "/users", "post", "parameters").reject { |p| p["in"] == "body" }
+      names = non_body.map { |p| p["name"] }
+
+      refute_includes names, "name", ":name must not appear as a non-body param in OAS2"
+      refute_includes names, "address", ":address must not appear as a non-body param in OAS2"
+    end
+  end
+end

--- a/test/grape_oas/api_model_builders/request_params_body_test.rb
+++ b/test/grape_oas/api_model_builders/request_params_body_test.rb
@@ -193,6 +193,145 @@ module GrapeOAS
         assert_includes body_schema.properties.keys, "data"
       end
 
+      # === Flat params default location by HTTP method ===
+
+      def test_post_flat_params_default_to_body
+        api_class = Class.new(Grape::API) do
+          format :json
+          params do
+            requires :name, type: String
+            requires :email, type: String
+          end
+          post "users" do
+            {}
+          end
+        end
+
+        route = api_class.routes.first
+        builder = RequestParams.new(api: @api, route: route)
+        body_schema, params = builder.build
+
+        assert_includes body_schema.properties.keys, "name"
+        assert_includes body_schema.properties.keys, "email"
+        assert_empty params, "Flat params in POST should go to body by default, not query"
+      end
+
+      def test_put_flat_params_default_to_body
+        api_class = Class.new(Grape::API) do
+          format :json
+          params do
+            requires :id, type: Integer
+            requires :title, type: String
+            optional :body, type: String
+          end
+          put "articles/:id" do
+            {}
+          end
+        end
+
+        route = api_class.routes.first
+        builder = RequestParams.new(api: @api, route: route)
+        body_schema, params = builder.build
+
+        assert_includes body_schema.properties.keys, "title"
+        assert_includes body_schema.properties.keys, "body"
+
+        id_param = params.find { |p| p.name == "id" }
+
+        assert_equal "path", id_param.location, "Path params are always path regardless of HTTP method"
+      end
+
+      def test_patch_flat_params_default_to_body
+        api_class = Class.new(Grape::API) do
+          format :json
+          params do
+            requires :id, type: Integer
+            optional :status, type: String
+          end
+          patch "orders/:id" do
+            {}
+          end
+        end
+
+        route = api_class.routes.first
+        builder = RequestParams.new(api: @api, route: route)
+        body_schema, params = builder.build
+
+        assert_includes body_schema.properties.keys, "status"
+
+        id_param = params.find { |p| p.name == "id" }
+
+        assert_equal "path", id_param.location, "Path params are always path regardless of HTTP method"
+      end
+
+      def test_get_flat_params_default_to_query
+        api_class = Class.new(Grape::API) do
+          format :json
+          params do
+            optional :filter, type: String
+            optional :page, type: Integer
+          end
+          get "items" do
+            {}
+          end
+        end
+
+        route = api_class.routes.first
+        builder = RequestParams.new(api: @api, route: route)
+        body_schema, params = builder.build
+
+        filter_param = params.find { |p| p.name == "filter" }
+        page_param = params.find { |p| p.name == "page" }
+
+        assert_equal "query", filter_param.location
+        assert_equal "query", page_param.location
+        assert_empty body_schema.properties, "GET flat params should stay as query, not go to body"
+      end
+
+      def test_delete_flat_params_default_to_query
+        api_class = Class.new(Grape::API) do
+          format :json
+          params do
+            optional :permanent, type: Grape::API::Boolean
+          end
+          delete "items/:id" do
+            {}
+          end
+        end
+
+        route = api_class.routes.first
+        builder = RequestParams.new(api: @api, route: route)
+        body_schema, params = builder.build
+
+        permanent_param = params.find { |p| p.name == "permanent" }
+
+        assert_equal "query", permanent_param.location
+        assert_empty body_schema.properties, "DELETE flat params should stay as query, not go to body"
+      end
+
+      def test_post_explicit_query_param_overrides_body_default
+        api_class = Class.new(Grape::API) do
+          format :json
+          params do
+            requires :name, type: String
+            optional :dry_run, type: Grape::API::Boolean, documentation: { param_type: "query" }
+          end
+          post "users" do
+            {}
+          end
+        end
+
+        route = api_class.routes.first
+        builder = RequestParams.new(api: @api, route: route)
+        body_schema, params = builder.build
+
+        assert_includes body_schema.properties.keys, "name"
+
+        dry_run_param = params.find { |p| p.name == "dry_run" }
+
+        assert_equal "query", dry_run_param.location, "Explicit param_type: 'query' should override POST body default"
+      end
+
       # === Mixed params with nested structures ===
 
       def test_mixed_query_and_body_with_nested

--- a/test/grape_oas/api_model_builders/request_params_features_test.rb
+++ b/test/grape_oas/api_model_builders/request_params_features_test.rb
@@ -512,13 +512,10 @@ module GrapeOAS
 
         route = api_class.routes.first
         builder = RequestParams.new(api: @api, route: route)
-        _body_schema, params = builder.build
+        body_schema, _params = builder.build
 
-        username_param = params.find { |p| p.name == "username" }
-        description_param = params.find { |p| p.name == "description" }
-
-        refute_nil username_param
-        refute_nil description_param
+        assert_includes body_schema.properties.keys, "username"
+        assert_includes body_schema.properties.keys, "description"
       end
 
       # === Pattern constraint ===
@@ -536,11 +533,9 @@ module GrapeOAS
 
         route = api_class.routes.first
         builder = RequestParams.new(api: @api, route: route)
-        _body_schema, params = builder.build
+        body_schema, _params = builder.build
 
-        email_param = params.find { |p| p.name == "email" }
-
-        refute_nil email_param
+        assert_includes body_schema.properties.keys, "email"
       end
     end
   end


### PR DESCRIPTION
Default to body params for POST/PUT/PATCH routes when no explicit param location is provided.

(This is how grape-swagger behaves.)