### PR TITLE
perf: memoize default_format and content_types resolution per generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#59](https://github.com/numbata/grape-oas/pull/59): Export `default` param values to OAS2 and OAS3 output - [@olivier-thatch](https://github.com/olivier-thatch).
 - Your contribution here
 
+### Changed
+
+- [#64](https://github.com/numbata/grape-oas/pull/64): Memoize `ContentTypeResolver#default_format_from_app_or_api` and `#content_types_from_app_or_api` per generation on a new `ApiModel::API#builder_cache` — these helpers are invoked once per route × response spec but only depend on `(api, app)`, which is constant for a generation run; the backing `app.default_format` walks Grape's `inheritable_setting.namespace_inheritable` at ~50–90 ms per call. Measured 97× cold-generation speedup on a ~140-route API (87.6 s → 0.9 s) - [@JuniorJoanis](https://github.com/JuniorJoanis).
+
 ## [1.3.0] - 2026-03-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- [#64](https://github.com/numbata/grape-oas/pull/64): Memoize `ContentTypeResolver#default_format_from_app_or_api` and `#content_types_from_app_or_api` per generation on a new `ApiModel::API#builder_cache` — these helpers are invoked once per route × response spec but only depend on `(api, app)`, which is constant for a generation run; the backing `app.default_format` walks Grape's `inheritable_setting.namespace_inheritable` at ~50–90 ms per call. Measured 97× cold-generation speedup on a ~140-route API (87.6 s → 0.9 s) - [@JuniorJoanis](https://github.com/JuniorJoanis).
+- [#64](https://github.com/numbata/grape-oas/pull/64): Memoize content-type and default-format resolution per generation — eliminates redundant calls that scaled with route × response count - [@JuniorJoanis](https://github.com/JuniorJoanis).
+- Your contribution here
 
 ## [1.3.0] - 2026-03-27
 

--- a/lib/grape_oas/api_model/api.rb
+++ b/lib/grape_oas/api_model/api.rb
@@ -38,6 +38,10 @@ module GrapeOAS
       def add_tags(*tags)
         @tag_defs.merge(tags)
       end
+
+      def builder_cache
+        @builder_cache ||= {}
+      end
     end
   end
 end

--- a/lib/grape_oas/api_model_builders/concerns/content_type_resolver.rb
+++ b/lib/grape_oas/api_model_builders/concerns/content_type_resolver.rb
@@ -57,6 +57,16 @@ module GrapeOAS
         end
 
         def default_format_from_app_or_api
+          return uncached_default_format_from_app_or_api unless api.respond_to?(:builder_cache)
+
+          cache = api.builder_cache
+          key = [:default_format, app.object_id]
+          return cache[key] if cache.key?(key)
+
+          cache[key] = uncached_default_format_from_app_or_api
+        end
+
+        def uncached_default_format_from_app_or_api
           return api.default_format if api.respond_to?(:default_format)
           return app.default_format if app_responds_to?(:default_format)
 
@@ -66,6 +76,16 @@ module GrapeOAS
         end
 
         def content_types_from_app_or_api(default_format)
+          return uncached_content_types_from_app_or_api(default_format) unless api.respond_to?(:builder_cache)
+
+          cache = api.builder_cache
+          key = [:content_types, app.object_id, default_format]
+          return cache[key] if cache.key?(key)
+
+          cache[key] = uncached_content_types_from_app_or_api(default_format)
+        end
+
+        def uncached_content_types_from_app_or_api(default_format)
           source = if api.respond_to?(:content_types)
                      api.content_types
                    elsif app_responds_to?(:content_types)

--- a/lib/grape_oas/api_model_builders/concerns/content_type_resolver.rb
+++ b/lib/grape_oas/api_model_builders/concerns/content_type_resolver.rb
@@ -82,7 +82,8 @@ module GrapeOAS
           key = [:content_types, app.object_id, default_format]
           return cache[key] if cache.key?(key)
 
-          cache[key] = uncached_content_types_from_app_or_api(default_format)
+          value = uncached_content_types_from_app_or_api(default_format)
+          cache[key] = value.is_a?(Hash) ? value.dup.freeze : value
         end
 
         def uncached_content_types_from_app_or_api(default_format)

--- a/test/grape_oas/api_model_builders/content_type_resolver_memoization_test.rb
+++ b/test/grape_oas/api_model_builders/content_type_resolver_memoization_test.rb
@@ -173,6 +173,35 @@ module GrapeOAS
                      "app.content_types must not be consulted when api.content_types answers"
       end
 
+      def test_content_types_cached_hash_is_frozen_and_decoupled_from_source
+        source = { "application/json" => :json }
+        @app.content_types_value = source
+
+        host = ResolverHost.new(api: @api, app: @app, route: @route)
+        cached = host.content_types_from_app_or_api(nil)
+
+        assert_predicate cached, :frozen?, "cached content-types hash must be frozen"
+        refute_same source, cached,
+                    "cached hash must be a copy so mutation of source cannot poison the cache"
+        assert_raises(FrozenError) { cached["text/csv"] = :csv }
+      end
+
+      def test_content_types_cache_survives_source_mutation
+        source = { "application/json" => :json }
+        @app.content_types_value = source
+
+        host = ResolverHost.new(api: @api, app: @app, route: @route)
+        first = host.content_types_from_app_or_api(nil)
+
+        source["application/xml"] = :xml
+
+        second = host.content_types_from_app_or_api(nil)
+
+        assert_equal first, second
+        refute_includes second.keys, "application/xml",
+                        "mutation of the source hash after caching must not leak into cached value"
+      end
+
       def test_resolve_content_types_is_stable_and_memoizes_underlying_helpers
         @app.default_format_value = :json
         @app.content_types_value = {

--- a/test/grape_oas/api_model_builders/content_type_resolver_memoization_test.rb
+++ b/test/grape_oas/api_model_builders/content_type_resolver_memoization_test.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GrapeOAS
+  module ApiModelBuilders
+    class ContentTypeResolverMemoizationTest < Minitest::Test
+      class ResolverHost
+        include Concerns::ContentTypeResolver
+
+        attr_reader :api, :app, :route
+
+        def initialize(api:, app:, route:)
+          @api = api
+          @app = app
+          @route = route
+        end
+
+        public :default_format_from_app_or_api, :content_types_from_app_or_api
+      end
+
+      class StubApp
+        attr_accessor :default_format_value, :content_types_value,
+                      :default_format_calls, :content_types_calls
+
+        def initialize
+          @default_format_calls = 0
+          @content_types_calls = 0
+        end
+
+        def default_format
+          @default_format_calls += 1
+          @default_format_value
+        end
+
+        def content_types
+          @content_types_calls += 1
+          @content_types_value
+        end
+      end
+
+      class StubApiWithFormat < GrapeOAS::ApiModel::API
+        attr_accessor :default_format_value, :content_types_value,
+                      :default_format_calls, :content_types_calls
+
+        def initialize(title: "Api Stub", version: "1.0")
+          super
+          @default_format_calls = 0
+          @content_types_calls = 0
+        end
+
+        def default_format
+          @default_format_calls += 1
+          @default_format_value
+        end
+
+        def content_types
+          @content_types_calls += 1
+          @content_types_value
+        end
+      end
+
+      StubRoute = Struct.new(:options, :settings) do
+        def self.empty
+          new({}, {})
+        end
+      end
+
+      def setup
+        @api = GrapeOAS::ApiModel::API.new(title: "Test API", version: "1.0")
+        @app = StubApp.new
+        @route = Object.new
+      end
+
+      def test_default_format_is_memoized_per_api
+        @app.default_format_value = :json
+
+        host = ResolverHost.new(api: @api, app: @app, route: @route)
+
+        assert_equal :json, host.default_format_from_app_or_api
+        assert_equal :json, host.default_format_from_app_or_api
+        assert_equal :json, host.default_format_from_app_or_api
+
+        assert_equal 1, @app.default_format_calls,
+                     "app.default_format should only be invoked once per (api, app) pair"
+      end
+
+      def test_default_format_cache_is_scoped_per_api_instance
+        @app.default_format_value = :json
+        other_api = GrapeOAS::ApiModel::API.new(title: "Other", version: "1.0")
+
+        host1 = ResolverHost.new(api: @api, app: @app, route: @route)
+        host2 = ResolverHost.new(api: other_api, app: @app, route: @route)
+
+        host1.default_format_from_app_or_api
+        host1.default_format_from_app_or_api
+        host2.default_format_from_app_or_api
+
+        assert_equal 2, @app.default_format_calls,
+                     "cache must not leak between API instances"
+      end
+
+      def test_default_format_falls_back_to_uncached_when_api_has_no_builder_cache
+        bare_api = Object.new
+        @app.default_format_value = :json
+
+        host = ResolverHost.new(api: bare_api, app: @app, route: @route)
+        host.default_format_from_app_or_api
+        host.default_format_from_app_or_api
+
+        assert_equal 2, @app.default_format_calls,
+                     "no memoization should occur when api does not expose builder_cache"
+      end
+
+      def test_default_format_caches_nil_value
+        @app.default_format_value = nil
+
+        host = ResolverHost.new(api: @api, app: @app, route: @route)
+        3.times { host.default_format_from_app_or_api }
+
+        assert_equal 1, @app.default_format_calls, "nil must be cached like any other value"
+      end
+
+      def test_default_format_memoizes_via_api_branch
+        api = StubApiWithFormat.new
+        api.default_format_value = :xml
+
+        host = ResolverHost.new(api: api, app: @app, route: @route)
+        3.times { host.default_format_from_app_or_api }
+
+        assert_equal 1, api.default_format_calls,
+                     "api.default_format must be invoked once even when api is the source"
+        assert_equal 0, @app.default_format_calls,
+                     "app.default_format must not be consulted when api.default_format answers"
+      end
+
+      def test_content_types_is_memoized_per_api_and_default_format
+        @app.content_types_value = { "application/json" => :json }
+
+        host = ResolverHost.new(api: @api, app: @app, route: @route)
+        host.content_types_from_app_or_api(:json)
+        host.content_types_from_app_or_api(:json)
+        host.content_types_from_app_or_api(:xml)
+
+        assert_equal 2, @app.content_types_calls, "should memoize per default_format key"
+      end
+
+      def test_content_types_cache_is_scoped_per_api_instance
+        @app.content_types_value = { "application/json" => :json }
+        other_api = GrapeOAS::ApiModel::API.new(title: "Other", version: "1.0")
+
+        host1 = ResolverHost.new(api: @api, app: @app, route: @route)
+        host2 = ResolverHost.new(api: other_api, app: @app, route: @route)
+
+        host1.content_types_from_app_or_api(:json)
+        host1.content_types_from_app_or_api(:json)
+        host2.content_types_from_app_or_api(:json)
+
+        assert_equal 2, @app.content_types_calls,
+                     "content_types cache must not leak between API instances"
+      end
+
+      def test_content_types_memoizes_via_api_branch
+        api = StubApiWithFormat.new
+        api.content_types_value = { "application/json" => :json }
+
+        host = ResolverHost.new(api: api, app: @app, route: @route)
+        3.times { host.content_types_from_app_or_api(:json) }
+
+        assert_equal 1, api.content_types_calls,
+                     "api.content_types must be invoked once even when api is the source"
+        assert_equal 0, @app.content_types_calls,
+                     "app.content_types must not be consulted when api.content_types answers"
+      end
+
+      def test_resolve_content_types_is_stable_and_memoizes_underlying_helpers
+        @app.default_format_value = :json
+        @app.content_types_value = {
+          "application/json" => :json,
+          "application/xml" => :xml
+        }
+
+        host = ResolverHost.new(api: @api, app: @app, route: StubRoute.empty)
+        host.singleton_class.send(:public, :resolve_content_types)
+
+        first = host.resolve_content_types
+        second = host.resolve_content_types
+        third = host.resolve_content_types
+
+        assert_equal first, second
+        assert_equal first, third
+        assert_equal ["application/json"], first,
+                     "default_format :json should select the application/json mime"
+        assert_equal 1, @app.default_format_calls,
+                     "app.default_format must be invoked once across repeated resolves"
+        assert_equal 1, @app.content_types_calls,
+                     "app.content_types must be invoked once across repeated resolves"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`Concerns::ContentTypeResolver#default_format_from_app_or_api` and `#content_types_from_app_or_api` are invoked once per `(route × response spec)` during a single `GrapeOAS.generate` call — but their return value depends only on `(api, app)`, which is constant across a generation. On a typical Grape API this expands to hundreds of identical calls.

On APIs with a deep mount tree, the backing `app.default_format` resolves through `Grape::DSL::RequestResponse#default_format`, which walks `inheritable_setting.namespace_inheritable[:default_format]`. We measured this at ~50–90 ms per call on a production API — making this one method responsible for **~65% of cold `GrapeOAS.generate` time**.

This PR memoizes both helpers on a new `ApiModel::API#builder_cache` (lifetime = one generation).

## Measured impact

Phase-instrumented cold generate, 142-route Grape API mounted under a namespace:

| | Before | After | Speedup |
|---|---:|---:|---:|
| Total | 87.6 s | **0.9 s** | **97×** |
| Per route | 617 ms | 6.4 ms | 97× |
| `response#build` share | 69.7 % | 1.8 % | — |
| `ctr#default_format_from_app_or_api` share | 65.1 % | 0.1 % | — |

Before (top rows of phase breakdown):

```
phase                                             calls  total(s)  % of tot  avg(ms)
operation#build                                     142     87.48     99.9%   616.060
response#build                                      142     56.16     69.7%   395.474
response#build_response_from_group                  624     56.15     69.7%    89.989
ctr#default_format_from_app_or_api                  624     56.28     65.1%    90.197  ←
```

Debug dump from the first call confirms it:

```
api.respond_to?(:default_format)       = false
app.respond_to?(:default_format)       = true
app.default_format                     = nil (took 53.803ms)
```

All 624 calls returned the same \`nil\`.

## Approach

- New \`ApiModel::API#builder_cache\` (plain \`Hash\` memoized on the API instance) serves as a per-generation bucket for any builder-concern memoization that depends on \`api\` and/or \`app\`.
- \`ContentTypeResolver#default_format_from_app_or_api\` is split into a thin memoizing wrapper + a renamed \`uncached_default_format_from_app_or_api\` containing the original body. Same pattern for \`content_types_from_app_or_api\`.
- When \`api\` does **not** respond to \`builder_cache\` (e.g. a custom DTO passed to a custom builder), the resolver falls back to the uncached path for full backward compatibility.

## Design choices I'd like your opinion on

1. **Memoization bucket location.** I put it on \`ApiModel::API\` because its lifetime matches a generation exactly. Alternatives I considered:
   - Resolving the values once at the top of the builder pipeline (\`ApiModelBuilder\`) and threading them down as constructor args — cleaner architecturally but a larger diff that touches \`Path\`, \`Operation\`, \`Response\` public signatures.
   - A module-level or \`Thread.current\` cache — rejected (shared-state / thread-safety / test isolation risks).

   The current approach is the smallest diff that achieves the speedup. Happy to switch to approach #1 if you prefer a cleaner refactor over a surgical fix. Maybe better to do in another PR.

2. **Naming.** I went with \`builder_cache\` to signal "used by builder concerns, not part of the public API". Open to \`resolver_cache\`, \`memo\`, \`__cache__\`, etc.

3. **Scope.** I only cached the two methods that showed up as hot in the profile. There may be other builder-concern helpers in the same situation (e.g. tag name resolution) — I'd rather add those in follow-ups so this PR stays single-purpose. Let me know if you'd prefer I sweep them in the same diff.

## Tests

- \`test/grape_oas/api_model_builders/content_type_resolver_memoization_test.rb\` — 9 tests / 18 assertionscovering:
  - \`default_format\` is invoked exactly once per \`(api, app)\` on repeated calls
  - cache is scoped per-API instance (no cross-generation leak)
  - \`nil\` values are cached
  - fall-back to uncached path when \`api\` doesn't expose \`builder_cache\`
  - \`content_types\` memoizes per \`(api, app, default_format)\` key

Full suite passes locally: `1197 runs, 3292 assertions, 0 failures, 0 errors, 7 skips` (skips pre-existing, Grape 3.2 compatibility). Rubocop clean.

## Backward compatibility

- Public API of \`ApiModel::API\` gains a new \`#builder_cache\` method. No existing methods or signatures are modified.
- \`ContentTypeResolver\`'s public surface is unchanged — the split into \`uncached_*\` helpers is all private.
- Existing callers that construct an \`ApiModel::API\` without going through \`GrapeOAS.generate\` still work: the cache just lives on that instance for its own lifetime.

## Context

Discovered while investigating a 14-minute cold \`GrapeOAS.generate\` on an internal Grape API. Happy to add a reproducer script if useful. Let me know how you'd like to proceed.