### PR TITLE
De-duplicate description between Parameter Object and its schema (OAS 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#57](https://github.com/numbata/grape-oas/pull/57): Fix `Array<Array<...>>` double-wrap when `is_array: true` is used with typed array notation like `type: [String]` — the redundant `is_array` flag no longer produces a nested array schema - [@numbata](https://github.com/numbata).
 - [#59](https://github.com/numbata/grape-oas/pull/59): Export `default` param values to OAS2 and OAS3 output - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#61](https://github.com/numbata/grape-oas/pull/61): Respect `entity_name` on `grape::entity` subclasses - [@olivier-thatch](https://github.com/olivier-thatch).
+- [#68](https://github.com/numbata/grape-oas/pull/68): De-duplicate parameter `description` between the Parameter Object and its nested `schema` in OAS 3 output — hoists description up to the Parameter Object and strips it from the schema, preventing tools like Swagger UI and Redoc from rendering duplicate text - [@olivier-thatch](https://github.com/olivier-thatch).
 - Your contribution here
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#57](https://github.com/numbata/grape-oas/pull/57): Fix `Array<Array<...>>` double-wrap when `is_array: true` is used with typed array notation like `type: [String]` — the redundant `is_array` flag no longer produces a nested array schema - [@numbata](https://github.com/numbata).
 - [#59](https://github.com/numbata/grape-oas/pull/59): Export `default` param values to OAS2 and OAS3 output - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#61](https://github.com/numbata/grape-oas/pull/61): Respect `entity_name` on `grape::entity` subclasses - [@olivier-thatch](https://github.com/olivier-thatch).
-- [#68](https://github.com/numbata/grape-oas/pull/68): De-duplicate parameter `description` between the Parameter Object and its nested `schema` in OAS 3 output — hoists description up to the Parameter Object and strips it from the schema, preventing tools like Swagger UI and Redoc from rendering duplicate text - [@olivier-thatch](https://github.com/olivier-thatch).
+- [#68](https://github.com/numbata/grape-oas/pull/68): De-duplicate parameter `description` between the Parameter Object and its nested `schema` in OAS 3 output - [@olivier-thatch](https://github.com/olivier-thatch).
 - Your contribution here
 
 ### Changed

--- a/lib/grape_oas/exporter/oas3/parameter.rb
+++ b/lib/grape_oas/exporter/oas3/parameter.rb
@@ -12,14 +12,17 @@ module GrapeOAS
 
         def build
           Array(@op.parameters).map do |param|
+            schema_hash = Schema.new(param.schema, @ref_tracker, nullable_strategy: @nullable_strategy).build
+            description = param.description || schema_hash.delete("description")
+            schema_hash.delete("description")
             {
               "name" => param.name,
               "in" => param.location,
               "required" => param.required,
-              "description" => param.description,
+              "description" => description,
               "style" => param.style,
               "explode" => param.explode,
-              "schema" => Schema.new(param.schema, @ref_tracker, nullable_strategy: @nullable_strategy).build
+              "schema" => schema_hash
             }.compact
           end.presence
         end

--- a/lib/grape_oas/exporter/oas3/parameter.rb
+++ b/lib/grape_oas/exporter/oas3/parameter.rb
@@ -13,8 +13,8 @@ module GrapeOAS
         def build
           Array(@op.parameters).map do |param|
             schema_hash = Schema.new(param.schema, @ref_tracker, nullable_strategy: @nullable_strategy).build
-            description = param.description || schema_hash.delete("description")
-            schema_hash.delete("description")
+            schema_description = schema_hash.delete("description")
+            description = param.description || schema_description
             {
               "name" => param.name,
               "in" => param.location,

--- a/test/grape_oas/exporter/oas3_parameter_test.rb
+++ b/test/grape_oas/exporter/oas3_parameter_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GrapeOAS
+  module Exporter
+    class OAS3ParameterTest < Minitest::Test
+      def test_description_not_duplicated_in_schema
+        schema = ApiModel::Schema.new(type: "integer", description: "Number of items")
+        param = ApiModel::Parameter.new(
+          location: "query",
+          name: "size",
+          schema: schema,
+          required: false,
+          description: "Number of items",
+        )
+        operation = ApiModel::Operation.new(http_method: "get", parameters: [param])
+
+        result = OAS3::Parameter.new(operation).build
+        size_param = result.first
+
+        assert_equal "Number of items", size_param["description"]
+        refute size_param["schema"].key?("description"),
+               "schema should not carry a description for in: query parameters"
+      end
+
+      def test_description_hoisted_from_schema_when_param_description_missing
+        schema = ApiModel::Schema.new(type: "integer", description: "Schema-only desc")
+        param = ApiModel::Parameter.new(
+          location: "query",
+          name: "size",
+          schema: schema,
+          required: false,
+          description: nil,
+        )
+        operation = ApiModel::Operation.new(http_method: "get", parameters: [param])
+
+        result = OAS3::Parameter.new(operation).build
+        size_param = result.first
+
+        assert_equal "Schema-only desc", size_param["description"]
+        refute size_param["schema"].key?("description")
+      end
+
+      def test_no_description_anywhere_when_neither_source_sets_it
+        schema = ApiModel::Schema.new(type: "integer")
+        param = ApiModel::Parameter.new(
+          location: "query",
+          name: "size",
+          schema: schema,
+          required: false,
+        )
+        operation = ApiModel::Operation.new(http_method: "get", parameters: [param])
+
+        result = OAS3::Parameter.new(operation).build
+        size_param = result.first
+
+        refute size_param.key?("description")
+        refute size_param["schema"].key?("description")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Query/path/header/cookie parameter descriptions were being emitted both at the OpenAPI Parameter Object top-level **and** inside the nested `schema` object, causing tools like Swagger UI and Redoc to render duplicate text.

### Before

```json
{
  "name": "page[size]",
  "in": "query",
  "description": "Number of items per page...",
  "schema": {
    "type": "integer",
    "description": "Number of items per page...",
    "minimum": 1,
    "maximum": 1000
  }
}
```

### After

```json
{
  "name": "page[size]",
  "in": "query",
  "description": "Number of items per page...",
  "schema": {
    "type": "integer",
    "minimum": 1,
    "maximum": 1000
  }
}
```

## Change

In `OAS3::Parameter#build`, after building the schema hash, hoist `description` up to the Parameter Object if it is not already set, then strip it from the nested schema.

Scope:
- Covers OAS 3.0 and 3.1 (they share the same `Parameter` class)
- Body schemas, reusable `components/schemas`, and nested object properties are unaffected — they do not flow through `OAS3::Parameter`
- OAS 2 was already emitting constraints inline (no nested schema) for primitive params, so no change there

## Test plan

- [x] New unit tests in `test/grape_oas/exporter/oas3_parameter_test.rb` cover:
  - description not duplicated in schema when both sources set it
  - description hoisted from schema when parameter-level description is missing
  - no description emitted anywhere when neither source sets it
- [x] Full test suite passes (1250 runs, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)