### PR TITLE
Propagate schema attributes through $ref and composition paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#59](https://github.com/numbata/grape-oas/pull/59): Export `default` param values to OAS2 and OAS3 output - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#61](https://github.com/numbata/grape-oas/pull/61): Respect `entity_name` on `grape::entity` subclasses - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#68](https://github.com/numbata/grape-oas/pull/68): De-duplicate parameter `description` between the Parameter Object and its nested `schema` in OAS 3 output - [@olivier-thatch](https://github.com/olivier-thatch).
+- [#70](https://github.com/numbata/grape-oas/pull/70): Propagate schema attributes (`default`, `enum`, constraints, extensions) through `$ref` and composition paths - [@numbata](https://github.com/numbata).
 - Your contribution here
 
 ### Changed

--- a/lib/grape_oas/exporter/oas2/schema.rb
+++ b/lib/grape_oas/exporter/oas2/schema.rb
@@ -129,6 +129,7 @@ module GrapeOAS
             end
             result["description"] = schema.description.to_s if schema.description
             result["default"] = schema.default unless schema.default.nil?
+            result["enum"] = schema.enum if schema.enum
             if result.empty?
               ref_hash
             else

--- a/lib/grape_oas/exporter/oas2/schema.rb
+++ b/lib/grape_oas/exporter/oas2/schema.rb
@@ -90,6 +90,7 @@ module GrapeOAS
           result = build_schema_or_ref(first_schema)
           result["description"] = @schema.description.to_s if @schema.description
           result["default"] = @schema.default unless @schema.default.nil?
+          result["enum"] = @schema.enum if @schema.enum
           apply_extensions(result)
           result
         end
@@ -103,6 +104,7 @@ module GrapeOAS
           result = { "allOf" => all_of_items }
           result["description"] = @schema.description.to_s if @schema.description
           result["default"] = @schema.default unless @schema.default.nil?
+          result["enum"] = @schema.enum if @schema.enum
           result["x-nullable"] = true if @nullable_strategy == Constants::NullableStrategy::EXTENSION && nullable?
           result
         end

--- a/lib/grape_oas/exporter/oas2/schema.rb
+++ b/lib/grape_oas/exporter/oas2/schema.rb
@@ -138,6 +138,7 @@ module GrapeOAS
             result["description"] = schema.description.to_s if schema.description
             result["default"] = schema.default unless schema.default.nil?
             result["enum"] = schema.enum if schema.enum
+            apply_constraints_from(result, schema)
             if result.empty?
               ref_hash
             else
@@ -149,6 +150,18 @@ module GrapeOAS
             built.delete("description") unless include_metadata
             built
           end
+        end
+
+        def apply_constraints_from(hash, schema)
+          hash["minimum"] = schema.minimum unless schema.minimum.nil?
+          hash["maximum"] = schema.maximum unless schema.maximum.nil?
+          hash["exclusiveMinimum"] = schema.exclusive_minimum if schema.exclusive_minimum
+          hash["exclusiveMaximum"] = schema.exclusive_maximum if schema.exclusive_maximum
+          hash["minLength"] = schema.min_length unless schema.min_length.nil?
+          hash["maxLength"] = schema.max_length unless schema.max_length.nil?
+          hash["pattern"] = schema.pattern if schema.pattern
+          hash["minItems"] = schema.min_items unless schema.min_items.nil?
+          hash["maxItems"] = schema.max_items unless schema.max_items.nil?
         end
 
         def normalize_enum(enum_vals, type)

--- a/lib/grape_oas/exporter/oas2/schema.rb
+++ b/lib/grape_oas/exporter/oas2/schema.rb
@@ -81,13 +81,19 @@ module GrapeOAS
 
         # Build schema from oneOf/anyOf by using first type (OAS2 doesn't support these)
         # Extensions are merged to allow x-anyOf/x-oneOf for consumers that support them
+        #
+        # Only description and extensions are applied from the composition node.
+        # Type-specific attributes (default, enum, format, constraints) are omitted
+        # because they describe the multi-type composition, not the single fallback
+        # branch selected here.
         def build_first_of_schema(composition_type)
           schemas = @schema.send(composition_type)
           first_schema = schemas.first
           return {} unless first_schema
 
           result = build_schema_or_ref(first_schema)
-          apply_composition_attributes(result)
+          result["description"] = @schema.description.to_s if @schema.description
+          apply_extensions(result)
           if result.key?("$ref") && result.size > 1
             ref = { "$ref" => result.delete("$ref") }
             result["allOf"] = [ref]

--- a/lib/grape_oas/exporter/oas2/schema.rb
+++ b/lib/grape_oas/exporter/oas2/schema.rb
@@ -129,6 +129,8 @@ module GrapeOAS
             if @nullable_strategy == Constants::NullableStrategy::EXTENSION && schema.respond_to?(:nullable) && schema.nullable
               result["x-nullable"] = true
             end
+            result["type"] = schema.type if schema.type
+            result["format"] = schema.format if schema.format
             result["description"] = schema.description.to_s if schema.description
             result["default"] = schema.default unless schema.default.nil?
             result["enum"] = schema.enum if schema.enum

--- a/lib/grape_oas/exporter/oas2/schema.rb
+++ b/lib/grape_oas/exporter/oas2/schema.rb
@@ -89,6 +89,7 @@ module GrapeOAS
           # Build the first schema as the fallback
           result = build_schema_or_ref(first_schema)
           result["description"] = @schema.description.to_s if @schema.description
+          result["default"] = @schema.default unless @schema.default.nil?
           apply_extensions(result)
           result
         end
@@ -101,6 +102,7 @@ module GrapeOAS
 
           result = { "allOf" => all_of_items }
           result["description"] = @schema.description.to_s if @schema.description
+          result["default"] = @schema.default unless @schema.default.nil?
           result["x-nullable"] = true if @nullable_strategy == Constants::NullableStrategy::EXTENSION && nullable?
           result
         end

--- a/lib/grape_oas/exporter/oas2/schema.rb
+++ b/lib/grape_oas/exporter/oas2/schema.rb
@@ -88,6 +88,8 @@ module GrapeOAS
 
           # Build the first schema as the fallback
           result = build_schema_or_ref(first_schema)
+          result["type"] = @schema.type if @schema.type
+          result["format"] = @schema.format if @schema.format
           result["description"] = @schema.description.to_s if @schema.description
           result["default"] = @schema.default unless @schema.default.nil?
           result["enum"] = @schema.enum if @schema.enum
@@ -102,6 +104,8 @@ module GrapeOAS
           end
 
           result = { "allOf" => all_of_items }
+          result["type"] = @schema.type if @schema.type
+          result["format"] = @schema.format if @schema.format
           result["description"] = @schema.description.to_s if @schema.description
           result["default"] = @schema.default unless @schema.default.nil?
           result["enum"] = @schema.enum if @schema.enum

--- a/lib/grape_oas/exporter/oas2/schema.rb
+++ b/lib/grape_oas/exporter/oas2/schema.rb
@@ -93,6 +93,7 @@ module GrapeOAS
           result["description"] = @schema.description.to_s if @schema.description
           result["default"] = @schema.default unless @schema.default.nil?
           result["enum"] = @schema.enum if @schema.enum
+          apply_constraints_from(result, @schema)
           apply_extensions(result)
           result
         end
@@ -109,6 +110,7 @@ module GrapeOAS
           result["description"] = @schema.description.to_s if @schema.description
           result["default"] = @schema.default unless @schema.default.nil?
           result["enum"] = @schema.enum if @schema.enum
+          apply_constraints_from(result, @schema)
           result["x-nullable"] = true if @nullable_strategy == Constants::NullableStrategy::EXTENSION && nullable?
           result
         end

--- a/lib/grape_oas/exporter/oas2/schema.rb
+++ b/lib/grape_oas/exporter/oas2/schema.rb
@@ -136,8 +136,6 @@ module GrapeOAS
             if @nullable_strategy == Constants::NullableStrategy::EXTENSION && schema.respond_to?(:nullable) && schema.nullable
               result["x-nullable"] = true
             end
-            result["type"] = schema.type if schema.type
-            result["format"] = schema.format if schema.format
             result["description"] = schema.description.to_s if schema.description
             result["default"] = schema.default unless schema.default.nil?
             result["enum"] = schema.enum if schema.enum

--- a/lib/grape_oas/exporter/oas2/schema.rb
+++ b/lib/grape_oas/exporter/oas2/schema.rb
@@ -88,6 +88,10 @@ module GrapeOAS
 
           result = build_schema_or_ref(first_schema)
           apply_composition_attributes(result)
+          if result.key?("$ref") && result.size > 1
+            ref = { "$ref" => result.delete("$ref") }
+            result["allOf"] = [ref]
+          end
           result
         end
 

--- a/lib/grape_oas/exporter/oas2/schema.rb
+++ b/lib/grape_oas/exporter/oas2/schema.rb
@@ -126,6 +126,7 @@ module GrapeOAS
               result["x-nullable"] = true
             end
             result["description"] = schema.description.to_s if schema.description
+            result["default"] = schema.default unless schema.default.nil?
             if result.empty?
               ref_hash
             else

--- a/lib/grape_oas/exporter/oas2/schema.rb
+++ b/lib/grape_oas/exporter/oas2/schema.rb
@@ -111,6 +111,7 @@ module GrapeOAS
           result["default"] = @schema.default unless @schema.default.nil?
           result["enum"] = @schema.enum if @schema.enum
           apply_constraints_from(result, @schema)
+          result.merge!(@schema.extensions) if @schema.extensions
           result["x-nullable"] = true if @nullable_strategy == Constants::NullableStrategy::EXTENSION && nullable?
           result
         end
@@ -141,6 +142,7 @@ module GrapeOAS
             result["default"] = schema.default unless schema.default.nil?
             result["enum"] = schema.enum if schema.enum
             apply_constraints_from(result, schema)
+            result.merge!(schema.extensions) if schema.extensions
             if result.empty?
               ref_hash
             else

--- a/lib/grape_oas/exporter/oas2/schema.rb
+++ b/lib/grape_oas/exporter/oas2/schema.rb
@@ -57,15 +57,15 @@ module GrapeOAS
         end
 
         def apply_constraints(schema_hash)
-          schema_hash["minLength"] = @schema.min_length if @schema.min_length
-          schema_hash["maxLength"] = @schema.max_length if @schema.max_length
+          schema_hash["minLength"] = @schema.min_length unless @schema.min_length.nil?
+          schema_hash["maxLength"] = @schema.max_length unless @schema.max_length.nil?
           schema_hash["pattern"] = @schema.pattern if @schema.pattern
-          schema_hash["minimum"] = @schema.minimum if @schema.minimum
-          schema_hash["maximum"] = @schema.maximum if @schema.maximum
+          schema_hash["minimum"] = @schema.minimum unless @schema.minimum.nil?
+          schema_hash["maximum"] = @schema.maximum unless @schema.maximum.nil?
           schema_hash["exclusiveMinimum"] = @schema.exclusive_minimum if @schema.exclusive_minimum
           schema_hash["exclusiveMaximum"] = @schema.exclusive_maximum if @schema.exclusive_maximum
-          schema_hash["minItems"] = @schema.min_items if @schema.min_items
-          schema_hash["maxItems"] = @schema.max_items if @schema.max_items
+          schema_hash["minItems"] = @schema.min_items unless @schema.min_items.nil?
+          schema_hash["maxItems"] = @schema.max_items unless @schema.max_items.nil?
         end
 
         def apply_extensions(schema_hash)
@@ -92,7 +92,7 @@ module GrapeOAS
           result["format"] = @schema.format if @schema.format
           result["description"] = @schema.description.to_s if @schema.description
           result["default"] = @schema.default unless @schema.default.nil?
-          result["enum"] = @schema.enum if @schema.enum
+          result["enum"] = normalize_enum(@schema.enum, @schema.type) if @schema.enum
           apply_constraints_from(result, @schema)
           apply_extensions(result)
           result
@@ -109,7 +109,7 @@ module GrapeOAS
           result["format"] = @schema.format if @schema.format
           result["description"] = @schema.description.to_s if @schema.description
           result["default"] = @schema.default unless @schema.default.nil?
-          result["enum"] = @schema.enum if @schema.enum
+          result["enum"] = normalize_enum(@schema.enum, @schema.type) if @schema.enum
           apply_constraints_from(result, @schema)
           result.merge!(@schema.extensions) if @schema.extensions
           result["x-nullable"] = true if @nullable_strategy == Constants::NullableStrategy::EXTENSION && nullable?
@@ -138,7 +138,7 @@ module GrapeOAS
             end
             result["description"] = schema.description.to_s if schema.description
             result["default"] = schema.default unless schema.default.nil?
-            result["enum"] = schema.enum if schema.enum
+            result["enum"] = normalize_enum(schema.enum, schema.type) if schema.enum
             apply_constraints_from(result, schema)
             result.merge!(schema.extensions) if schema.extensions
             if result.empty?

--- a/lib/grape_oas/exporter/oas2/schema.rb
+++ b/lib/grape_oas/exporter/oas2/schema.rb
@@ -86,8 +86,20 @@ module GrapeOAS
           first_schema = schemas.first
           return {} unless first_schema
 
-          # Build the first schema as the fallback
           result = build_schema_or_ref(first_schema)
+          apply_composition_attributes(result)
+          result
+        end
+
+        # Build allOf schema for inheritance
+        def build_all_of_schema
+          items = @schema.all_of.map { |item| build_schema_or_ref(item) }
+          result = { "allOf" => items }
+          apply_composition_attributes(result)
+          result
+        end
+
+        def apply_composition_attributes(result)
           result["type"] = @schema.type if @schema.type
           result["format"] = @schema.format if @schema.format
           result["description"] = @schema.description.to_s if @schema.description
@@ -95,25 +107,6 @@ module GrapeOAS
           result["enum"] = normalize_enum(@schema.enum, @schema.type) if @schema.enum
           apply_constraints(result)
           apply_extensions(result)
-          result
-        end
-
-        # Build allOf schema for inheritance
-        def build_all_of_schema
-          all_of_items = @schema.all_of.map do |item|
-            build_schema_or_ref(item)
-          end
-
-          result = { "allOf" => all_of_items }
-          result["type"] = @schema.type if @schema.type
-          result["format"] = @schema.format if @schema.format
-          result["description"] = @schema.description.to_s if @schema.description
-          result["default"] = @schema.default unless @schema.default.nil?
-          result["enum"] = normalize_enum(@schema.enum, @schema.type) if @schema.enum
-          apply_constraints(result)
-          result.merge!(@schema.extensions) if @schema.extensions
-          result["x-nullable"] = true if @nullable_strategy == Constants::NullableStrategy::EXTENSION && nullable?
-          result
         end
 
         def build_properties(properties)

--- a/lib/grape_oas/exporter/oas2/schema.rb
+++ b/lib/grape_oas/exporter/oas2/schema.rb
@@ -56,16 +56,16 @@ module GrapeOAS
           schema_hash
         end
 
-        def apply_constraints(schema_hash)
-          schema_hash["minLength"] = @schema.min_length unless @schema.min_length.nil?
-          schema_hash["maxLength"] = @schema.max_length unless @schema.max_length.nil?
-          schema_hash["pattern"] = @schema.pattern if @schema.pattern
-          schema_hash["minimum"] = @schema.minimum unless @schema.minimum.nil?
-          schema_hash["maximum"] = @schema.maximum unless @schema.maximum.nil?
-          schema_hash["exclusiveMinimum"] = @schema.exclusive_minimum if @schema.exclusive_minimum
-          schema_hash["exclusiveMaximum"] = @schema.exclusive_maximum if @schema.exclusive_maximum
-          schema_hash["minItems"] = @schema.min_items unless @schema.min_items.nil?
-          schema_hash["maxItems"] = @schema.max_items unless @schema.max_items.nil?
+        def apply_constraints(schema_hash, schema = @schema)
+          schema_hash["minimum"] = schema.minimum unless schema.minimum.nil?
+          schema_hash["maximum"] = schema.maximum unless schema.maximum.nil?
+          schema_hash["exclusiveMinimum"] = schema.exclusive_minimum if schema.exclusive_minimum
+          schema_hash["exclusiveMaximum"] = schema.exclusive_maximum if schema.exclusive_maximum
+          schema_hash["minLength"] = schema.min_length unless schema.min_length.nil?
+          schema_hash["maxLength"] = schema.max_length unless schema.max_length.nil?
+          schema_hash["pattern"] = schema.pattern if schema.pattern
+          schema_hash["minItems"] = schema.min_items unless schema.min_items.nil?
+          schema_hash["maxItems"] = schema.max_items unless schema.max_items.nil?
         end
 
         def apply_extensions(schema_hash)
@@ -93,7 +93,7 @@ module GrapeOAS
           result["description"] = @schema.description.to_s if @schema.description
           result["default"] = @schema.default unless @schema.default.nil?
           result["enum"] = normalize_enum(@schema.enum, @schema.type) if @schema.enum
-          apply_constraints_from(result, @schema)
+          apply_constraints(result)
           apply_extensions(result)
           result
         end
@@ -110,7 +110,7 @@ module GrapeOAS
           result["description"] = @schema.description.to_s if @schema.description
           result["default"] = @schema.default unless @schema.default.nil?
           result["enum"] = normalize_enum(@schema.enum, @schema.type) if @schema.enum
-          apply_constraints_from(result, @schema)
+          apply_constraints(result)
           result.merge!(@schema.extensions) if @schema.extensions
           result["x-nullable"] = true if @nullable_strategy == Constants::NullableStrategy::EXTENSION && nullable?
           result
@@ -139,7 +139,7 @@ module GrapeOAS
             result["description"] = schema.description.to_s if schema.description
             result["default"] = schema.default unless schema.default.nil?
             result["enum"] = normalize_enum(schema.enum, schema.type) if schema.enum
-            apply_constraints_from(result, schema)
+            apply_constraints(result, schema)
             result.merge!(schema.extensions) if schema.extensions
             if result.empty?
               ref_hash
@@ -152,18 +152,6 @@ module GrapeOAS
             built.delete("description") unless include_metadata
             built
           end
-        end
-
-        def apply_constraints_from(hash, schema)
-          hash["minimum"] = schema.minimum unless schema.minimum.nil?
-          hash["maximum"] = schema.maximum unless schema.maximum.nil?
-          hash["exclusiveMinimum"] = schema.exclusive_minimum if schema.exclusive_minimum
-          hash["exclusiveMaximum"] = schema.exclusive_maximum if schema.exclusive_maximum
-          hash["minLength"] = schema.min_length unless schema.min_length.nil?
-          hash["maxLength"] = schema.max_length unless schema.max_length.nil?
-          hash["pattern"] = schema.pattern if schema.pattern
-          hash["minItems"] = schema.min_items unless schema.min_items.nil?
-          hash["maxItems"] = schema.max_items unless schema.max_items.nil?
         end
 
         def normalize_enum(enum_vals, type)

--- a/lib/grape_oas/exporter/oas3/schema.rb
+++ b/lib/grape_oas/exporter/oas3/schema.rb
@@ -175,6 +175,7 @@ module GrapeOAS
 
             result = {}
             result["description"] = schema.description.to_s if schema.description
+            result["default"] = schema.default unless schema.default.nil?
             apply_nullable_to_ref(result, schema)
             if result.empty?
               ref_hash

--- a/lib/grape_oas/exporter/oas3/schema.rb
+++ b/lib/grape_oas/exporter/oas3/schema.rb
@@ -192,8 +192,6 @@ module GrapeOAS
             return ref_hash unless include_metadata
 
             result = {}
-            result["type"] = schema.type if schema.type
-            result["format"] = schema.format if schema.format
             result["description"] = schema.description.to_s if schema.description
             result["default"] = schema.default unless schema.default.nil?
             result["enum"] = schema.enum if schema.enum

--- a/lib/grape_oas/exporter/oas3/schema.rb
+++ b/lib/grape_oas/exporter/oas3/schema.rb
@@ -93,6 +93,7 @@ module GrapeOAS
           result["description"] = @schema.description.to_s if @schema.description
           result["default"] = @schema.default unless @schema.default.nil?
           result["enum"] = @schema.enum if @schema.enum
+          apply_constraints_from(result, @schema)
           apply_nullable(result)
           result
         end
@@ -109,6 +110,7 @@ module GrapeOAS
           result["description"] = @schema.description.to_s if @schema.description
           result["default"] = @schema.default unless @schema.default.nil?
           result["enum"] = @schema.enum if @schema.enum
+          apply_constraints_from(result, @schema)
           result["discriminator"] = build_discriminator if @schema.discriminator
           apply_nullable(result)
           result
@@ -126,6 +128,7 @@ module GrapeOAS
           result["description"] = @schema.description.to_s if @schema.description
           result["default"] = @schema.default unless @schema.default.nil?
           result["enum"] = @schema.enum if @schema.enum
+          apply_constraints_from(result, @schema)
           result["discriminator"] = build_discriminator if @schema.discriminator
           apply_nullable(result)
           result

--- a/lib/grape_oas/exporter/oas3/schema.rb
+++ b/lib/grape_oas/exporter/oas3/schema.rb
@@ -179,6 +179,7 @@ module GrapeOAS
             result["description"] = schema.description.to_s if schema.description
             result["default"] = schema.default unless schema.default.nil?
             result["enum"] = normalize_enum(schema.enum, schema.type) if schema.enum
+            sanitize_enum_against_type(result, type: schema.type)
             apply_all_constraints(result, schema)
             result.merge!(schema.extensions) if schema.extensions
             apply_nullable_to_ref(result, schema)
@@ -262,9 +263,9 @@ module GrapeOAS
         end
 
         # Ensure enum values match the declared type; drop enum if incompatible to avoid invalid specs
-        def sanitize_enum_against_type(hash)
+        def sanitize_enum_against_type(hash, type: hash["type"])
           enum_vals = hash["enum"]
-          type_val = hash["type"]
+          type_val = type
           return unless enum_vals && type_val
 
           base_type = if type_val.is_a?(Array)

--- a/lib/grape_oas/exporter/oas3/schema.rb
+++ b/lib/grape_oas/exporter/oas3/schema.rb
@@ -83,36 +83,18 @@ module GrapeOAS
 
         # Build allOf schema for inheritance
         def build_all_of_schema
-          all_of_items = @schema.all_of.map do |item|
-            build_schema_or_ref(item)
-          end
-
-          result = { "allOf" => all_of_items }
-          result["type"] = @schema.type if @schema.type
-          result["format"] = @schema.format if @schema.format
-          result["description"] = @schema.description.to_s if @schema.description
-          result["default"] = @schema.default unless @schema.default.nil?
-          result["enum"] = normalize_enum(@schema.enum, @schema.type) if @schema.enum
-          apply_all_constraints(result)
-          result.merge!(@schema.extensions) if @schema.extensions
+          items = @schema.all_of.map { |item| build_schema_or_ref(item) }
+          result = { "allOf" => items }
+          apply_composition_attributes(result)
           apply_nullable(result)
           result
         end
 
         # Build oneOf schema for polymorphism
         def build_one_of_schema
-          one_of_items = @schema.one_of.map do |item|
-            build_schema_or_ref(item)
-          end
-
-          result = { "oneOf" => one_of_items }
-          result["type"] = @schema.type if @schema.type
-          result["format"] = @schema.format if @schema.format
-          result["description"] = @schema.description.to_s if @schema.description
-          result["default"] = @schema.default unless @schema.default.nil?
-          result["enum"] = normalize_enum(@schema.enum, @schema.type) if @schema.enum
-          apply_all_constraints(result)
-          result.merge!(@schema.extensions) if @schema.extensions
+          items = @schema.one_of.map { |item| build_schema_or_ref(item) }
+          result = { "oneOf" => items }
+          apply_composition_attributes(result)
           result["discriminator"] = build_discriminator if @schema.discriminator
           apply_nullable(result)
           result
@@ -120,11 +102,15 @@ module GrapeOAS
 
         # Build anyOf schema for polymorphism
         def build_any_of_schema
-          any_of_items = @schema.any_of.map do |item|
-            build_schema_or_ref(item)
-          end
+          items = @schema.any_of.map { |item| build_schema_or_ref(item) }
+          result = { "anyOf" => items }
+          apply_composition_attributes(result)
+          result["discriminator"] = build_discriminator if @schema.discriminator
+          apply_nullable(result)
+          result
+        end
 
-          result = { "anyOf" => any_of_items }
+        def apply_composition_attributes(result)
           result["type"] = @schema.type if @schema.type
           result["format"] = @schema.format if @schema.format
           result["description"] = @schema.description.to_s if @schema.description
@@ -132,9 +118,6 @@ module GrapeOAS
           result["enum"] = normalize_enum(@schema.enum, @schema.type) if @schema.enum
           apply_all_constraints(result)
           result.merge!(@schema.extensions) if @schema.extensions
-          result["discriminator"] = build_discriminator if @schema.discriminator
-          apply_nullable(result)
-          result
         end
 
         # Build OAS3 discriminator object

--- a/lib/grape_oas/exporter/oas3/schema.rb
+++ b/lib/grape_oas/exporter/oas3/schema.rb
@@ -94,6 +94,7 @@ module GrapeOAS
           result["default"] = @schema.default unless @schema.default.nil?
           result["enum"] = @schema.enum if @schema.enum
           apply_constraints_from(result, @schema)
+          result.merge!(@schema.extensions) if @schema.extensions
           apply_nullable(result)
           result
         end
@@ -111,6 +112,7 @@ module GrapeOAS
           result["default"] = @schema.default unless @schema.default.nil?
           result["enum"] = @schema.enum if @schema.enum
           apply_constraints_from(result, @schema)
+          result.merge!(@schema.extensions) if @schema.extensions
           result["discriminator"] = build_discriminator if @schema.discriminator
           apply_nullable(result)
           result
@@ -129,6 +131,7 @@ module GrapeOAS
           result["default"] = @schema.default unless @schema.default.nil?
           result["enum"] = @schema.enum if @schema.enum
           apply_constraints_from(result, @schema)
+          result.merge!(@schema.extensions) if @schema.extensions
           result["discriminator"] = build_discriminator if @schema.discriminator
           apply_nullable(result)
           result
@@ -195,6 +198,7 @@ module GrapeOAS
             result["default"] = schema.default unless schema.default.nil?
             result["enum"] = schema.enum if schema.enum
             apply_constraints_from(result, schema)
+            result.merge!(schema.extensions) if schema.extensions
             apply_nullable_to_ref(result, schema)
             if result.empty?
               ref_hash

--- a/lib/grape_oas/exporter/oas3/schema.rb
+++ b/lib/grape_oas/exporter/oas3/schema.rb
@@ -111,7 +111,7 @@ module GrapeOAS
         end
 
         def apply_composition_attributes(result)
-          result["type"] = @schema.type if @schema.type
+          result["type"] = nullable_type if @schema.type
           result["format"] = @schema.format if @schema.format
           result["description"] = @schema.description.to_s if @schema.description
           result["default"] = @schema.default unless @schema.default.nil?

--- a/lib/grape_oas/exporter/oas3/schema.rb
+++ b/lib/grape_oas/exporter/oas3/schema.rb
@@ -73,10 +73,10 @@ module GrapeOAS
           schema_hash["discriminator"] = build_discriminator if @schema.discriminator
         end
 
-        def apply_all_constraints(schema_hash)
-          apply_numeric_constraints(schema_hash)
-          apply_string_constraints(schema_hash)
-          apply_array_constraints(schema_hash)
+        def apply_all_constraints(schema_hash, schema = @schema)
+          apply_numeric_constraints(schema_hash, schema)
+          apply_string_constraints(schema_hash, schema)
+          apply_array_constraints(schema_hash, schema)
         end
 
         private
@@ -93,7 +93,7 @@ module GrapeOAS
           result["description"] = @schema.description.to_s if @schema.description
           result["default"] = @schema.default unless @schema.default.nil?
           result["enum"] = normalize_enum(@schema.enum, @schema.type) if @schema.enum
-          apply_constraints_from(result, @schema)
+          apply_all_constraints(result)
           result.merge!(@schema.extensions) if @schema.extensions
           apply_nullable(result)
           result
@@ -111,7 +111,7 @@ module GrapeOAS
           result["description"] = @schema.description.to_s if @schema.description
           result["default"] = @schema.default unless @schema.default.nil?
           result["enum"] = normalize_enum(@schema.enum, @schema.type) if @schema.enum
-          apply_constraints_from(result, @schema)
+          apply_all_constraints(result)
           result.merge!(@schema.extensions) if @schema.extensions
           result["discriminator"] = build_discriminator if @schema.discriminator
           apply_nullable(result)
@@ -130,7 +130,7 @@ module GrapeOAS
           result["description"] = @schema.description.to_s if @schema.description
           result["default"] = @schema.default unless @schema.default.nil?
           result["enum"] = normalize_enum(@schema.enum, @schema.type) if @schema.enum
-          apply_constraints_from(result, @schema)
+          apply_all_constraints(result)
           result.merge!(@schema.extensions) if @schema.extensions
           result["discriminator"] = build_discriminator if @schema.discriminator
           apply_nullable(result)
@@ -195,7 +195,7 @@ module GrapeOAS
             result["description"] = schema.description.to_s if schema.description
             result["default"] = schema.default unless schema.default.nil?
             result["enum"] = normalize_enum(schema.enum, schema.type) if schema.enum
-            apply_constraints_from(result, schema)
+            apply_all_constraints(result, schema)
             result.merge!(schema.extensions) if schema.extensions
             apply_nullable_to_ref(result, schema)
             if result.empty?
@@ -247,7 +247,7 @@ module GrapeOAS
           result
         end
 
-        def apply_constraints_from(hash, schema)
+        def apply_numeric_constraints(hash, schema = @schema)
           hash["minimum"] = schema.minimum unless schema.minimum.nil?
           hash["maximum"] = schema.maximum unless schema.maximum.nil?
 
@@ -264,42 +264,17 @@ module GrapeOAS
             hash["exclusiveMinimum"] = schema.exclusive_minimum if schema.exclusive_minimum
             hash["exclusiveMaximum"] = schema.exclusive_maximum if schema.exclusive_maximum
           end
+        end
 
+        def apply_string_constraints(hash, schema = @schema)
           hash["minLength"] = schema.min_length unless schema.min_length.nil?
           hash["maxLength"] = schema.max_length unless schema.max_length.nil?
           hash["pattern"] = schema.pattern if schema.pattern
+        end
+
+        def apply_array_constraints(hash, schema = @schema)
           hash["minItems"] = schema.min_items unless schema.min_items.nil?
           hash["maxItems"] = schema.max_items unless schema.max_items.nil?
-        end
-
-        def apply_numeric_constraints(hash)
-          hash["minimum"] = @schema.minimum unless @schema.minimum.nil?
-          hash["maximum"] = @schema.maximum unless @schema.maximum.nil?
-
-          if @nullable_strategy == Constants::NullableStrategy::TYPE_ARRAY
-            if @schema.exclusive_minimum && !@schema.minimum.nil?
-              hash["exclusiveMinimum"] = @schema.minimum
-              hash.delete("minimum")
-            end
-            if @schema.exclusive_maximum && !@schema.maximum.nil?
-              hash["exclusiveMaximum"] = @schema.maximum
-              hash.delete("maximum")
-            end
-          else
-            hash["exclusiveMinimum"] = @schema.exclusive_minimum if @schema.exclusive_minimum
-            hash["exclusiveMaximum"] = @schema.exclusive_maximum if @schema.exclusive_maximum
-          end
-        end
-
-        def apply_string_constraints(hash)
-          hash["minLength"] = @schema.min_length unless @schema.min_length.nil?
-          hash["maxLength"] = @schema.max_length unless @schema.max_length.nil?
-          hash["pattern"] = @schema.pattern if @schema.pattern
-        end
-
-        def apply_array_constraints(hash)
-          hash["minItems"] = @schema.min_items unless @schema.min_items.nil?
-          hash["maxItems"] = @schema.max_items unless @schema.max_items.nil?
         end
 
         # Ensure enum values match the declared type; drop enum if incompatible to avoid invalid specs

--- a/lib/grape_oas/exporter/oas3/schema.rb
+++ b/lib/grape_oas/exporter/oas3/schema.rb
@@ -179,6 +179,7 @@ module GrapeOAS
             result = {}
             result["description"] = schema.description.to_s if schema.description
             result["default"] = schema.default unless schema.default.nil?
+            result["enum"] = schema.enum if schema.enum
             apply_nullable_to_ref(result, schema)
             if result.empty?
               ref_hash

--- a/lib/grape_oas/exporter/oas3/schema.rb
+++ b/lib/grape_oas/exporter/oas3/schema.rb
@@ -90,6 +90,7 @@ module GrapeOAS
           result = { "allOf" => all_of_items }
           result["description"] = @schema.description.to_s if @schema.description
           result["default"] = @schema.default unless @schema.default.nil?
+          result["enum"] = @schema.enum if @schema.enum
           apply_nullable(result)
           result
         end
@@ -103,6 +104,7 @@ module GrapeOAS
           result = { "oneOf" => one_of_items }
           result["description"] = @schema.description.to_s if @schema.description
           result["default"] = @schema.default unless @schema.default.nil?
+          result["enum"] = @schema.enum if @schema.enum
           result["discriminator"] = build_discriminator if @schema.discriminator
           apply_nullable(result)
           result
@@ -117,6 +119,7 @@ module GrapeOAS
           result = { "anyOf" => any_of_items }
           result["description"] = @schema.description.to_s if @schema.description
           result["default"] = @schema.default unless @schema.default.nil?
+          result["enum"] = @schema.enum if @schema.enum
           result["discriminator"] = build_discriminator if @schema.discriminator
           apply_nullable(result)
           result

--- a/lib/grape_oas/exporter/oas3/schema.rb
+++ b/lib/grape_oas/exporter/oas3/schema.rb
@@ -88,6 +88,8 @@ module GrapeOAS
           end
 
           result = { "allOf" => all_of_items }
+          result["type"] = @schema.type if @schema.type
+          result["format"] = @schema.format if @schema.format
           result["description"] = @schema.description.to_s if @schema.description
           result["default"] = @schema.default unless @schema.default.nil?
           result["enum"] = @schema.enum if @schema.enum
@@ -102,6 +104,8 @@ module GrapeOAS
           end
 
           result = { "oneOf" => one_of_items }
+          result["type"] = @schema.type if @schema.type
+          result["format"] = @schema.format if @schema.format
           result["description"] = @schema.description.to_s if @schema.description
           result["default"] = @schema.default unless @schema.default.nil?
           result["enum"] = @schema.enum if @schema.enum
@@ -117,6 +121,8 @@ module GrapeOAS
           end
 
           result = { "anyOf" => any_of_items }
+          result["type"] = @schema.type if @schema.type
+          result["format"] = @schema.format if @schema.format
           result["description"] = @schema.description.to_s if @schema.description
           result["default"] = @schema.default unless @schema.default.nil?
           result["enum"] = @schema.enum if @schema.enum

--- a/lib/grape_oas/exporter/oas3/schema.rb
+++ b/lib/grape_oas/exporter/oas3/schema.rb
@@ -263,9 +263,9 @@ module GrapeOAS
         end
 
         # Ensure enum values match the declared type; drop enum if incompatible to avoid invalid specs
-        def sanitize_enum_against_type(hash, type: hash["type"])
+        def sanitize_enum_against_type(hash, type: nil)
           enum_vals = hash["enum"]
-          type_val = type
+          type_val = type || hash["type"]
           return unless enum_vals && type_val
 
           base_type = if type_val.is_a?(Array)

--- a/lib/grape_oas/exporter/oas3/schema.rb
+++ b/lib/grape_oas/exporter/oas3/schema.rb
@@ -89,6 +89,7 @@ module GrapeOAS
 
           result = { "allOf" => all_of_items }
           result["description"] = @schema.description.to_s if @schema.description
+          result["default"] = @schema.default unless @schema.default.nil?
           apply_nullable(result)
           result
         end
@@ -101,6 +102,7 @@ module GrapeOAS
 
           result = { "oneOf" => one_of_items }
           result["description"] = @schema.description.to_s if @schema.description
+          result["default"] = @schema.default unless @schema.default.nil?
           result["discriminator"] = build_discriminator if @schema.discriminator
           apply_nullable(result)
           result
@@ -114,6 +116,7 @@ module GrapeOAS
 
           result = { "anyOf" => any_of_items }
           result["description"] = @schema.description.to_s if @schema.description
+          result["default"] = @schema.default unless @schema.default.nil?
           result["discriminator"] = build_discriminator if @schema.discriminator
           apply_nullable(result)
           result

--- a/lib/grape_oas/exporter/oas3/schema.rb
+++ b/lib/grape_oas/exporter/oas3/schema.rb
@@ -115,7 +115,7 @@ module GrapeOAS
           result["format"] = @schema.format if @schema.format
           result["description"] = @schema.description.to_s if @schema.description
           result["default"] = @schema.default unless @schema.default.nil?
-          result["enum"] = normalize_enum(@schema.enum, @schema.type) if @schema.enum
+          result["enum"] = normalize_enum(@schema.enum, result["type"]) if @schema.enum
           apply_all_constraints(result)
           result.merge!(@schema.extensions) if @schema.extensions
         end

--- a/lib/grape_oas/exporter/oas3/schema.rb
+++ b/lib/grape_oas/exporter/oas3/schema.rb
@@ -92,7 +92,7 @@ module GrapeOAS
           result["format"] = @schema.format if @schema.format
           result["description"] = @schema.description.to_s if @schema.description
           result["default"] = @schema.default unless @schema.default.nil?
-          result["enum"] = @schema.enum if @schema.enum
+          result["enum"] = normalize_enum(@schema.enum, @schema.type) if @schema.enum
           apply_constraints_from(result, @schema)
           result.merge!(@schema.extensions) if @schema.extensions
           apply_nullable(result)
@@ -110,7 +110,7 @@ module GrapeOAS
           result["format"] = @schema.format if @schema.format
           result["description"] = @schema.description.to_s if @schema.description
           result["default"] = @schema.default unless @schema.default.nil?
-          result["enum"] = @schema.enum if @schema.enum
+          result["enum"] = normalize_enum(@schema.enum, @schema.type) if @schema.enum
           apply_constraints_from(result, @schema)
           result.merge!(@schema.extensions) if @schema.extensions
           result["discriminator"] = build_discriminator if @schema.discriminator
@@ -129,7 +129,7 @@ module GrapeOAS
           result["format"] = @schema.format if @schema.format
           result["description"] = @schema.description.to_s if @schema.description
           result["default"] = @schema.default unless @schema.default.nil?
-          result["enum"] = @schema.enum if @schema.enum
+          result["enum"] = normalize_enum(@schema.enum, @schema.type) if @schema.enum
           apply_constraints_from(result, @schema)
           result.merge!(@schema.extensions) if @schema.extensions
           result["discriminator"] = build_discriminator if @schema.discriminator
@@ -194,7 +194,7 @@ module GrapeOAS
             result = {}
             result["description"] = schema.description.to_s if schema.description
             result["default"] = schema.default unless schema.default.nil?
-            result["enum"] = schema.enum if schema.enum
+            result["enum"] = normalize_enum(schema.enum, schema.type) if schema.enum
             apply_constraints_from(result, schema)
             result.merge!(schema.extensions) if schema.extensions
             apply_nullable_to_ref(result, schema)
@@ -250,8 +250,21 @@ module GrapeOAS
         def apply_constraints_from(hash, schema)
           hash["minimum"] = schema.minimum unless schema.minimum.nil?
           hash["maximum"] = schema.maximum unless schema.maximum.nil?
-          hash["exclusiveMinimum"] = schema.exclusive_minimum if schema.exclusive_minimum
-          hash["exclusiveMaximum"] = schema.exclusive_maximum if schema.exclusive_maximum
+
+          if @nullable_strategy == Constants::NullableStrategy::TYPE_ARRAY
+            if schema.exclusive_minimum && !schema.minimum.nil?
+              hash["exclusiveMinimum"] = schema.minimum
+              hash.delete("minimum")
+            end
+            if schema.exclusive_maximum && !schema.maximum.nil?
+              hash["exclusiveMaximum"] = schema.maximum
+              hash.delete("maximum")
+            end
+          else
+            hash["exclusiveMinimum"] = schema.exclusive_minimum if schema.exclusive_minimum
+            hash["exclusiveMaximum"] = schema.exclusive_maximum if schema.exclusive_maximum
+          end
+
           hash["minLength"] = schema.min_length unless schema.min_length.nil?
           hash["maxLength"] = schema.max_length unless schema.max_length.nil?
           hash["pattern"] = schema.pattern if schema.pattern

--- a/lib/grape_oas/exporter/oas3/schema.rb
+++ b/lib/grape_oas/exporter/oas3/schema.rb
@@ -191,6 +191,7 @@ module GrapeOAS
             result["description"] = schema.description.to_s if schema.description
             result["default"] = schema.default unless schema.default.nil?
             result["enum"] = schema.enum if schema.enum
+            apply_constraints_from(result, schema)
             apply_nullable_to_ref(result, schema)
             if result.empty?
               ref_hash
@@ -239,6 +240,18 @@ module GrapeOAS
           return nil if result.empty?
 
           result
+        end
+
+        def apply_constraints_from(hash, schema)
+          hash["minimum"] = schema.minimum unless schema.minimum.nil?
+          hash["maximum"] = schema.maximum unless schema.maximum.nil?
+          hash["exclusiveMinimum"] = schema.exclusive_minimum if schema.exclusive_minimum
+          hash["exclusiveMaximum"] = schema.exclusive_maximum if schema.exclusive_maximum
+          hash["minLength"] = schema.min_length unless schema.min_length.nil?
+          hash["maxLength"] = schema.max_length unless schema.max_length.nil?
+          hash["pattern"] = schema.pattern if schema.pattern
+          hash["minItems"] = schema.min_items unless schema.min_items.nil?
+          hash["maxItems"] = schema.max_items unless schema.max_items.nil?
         end
 
         def apply_numeric_constraints(hash)

--- a/lib/grape_oas/exporter/oas3/schema.rb
+++ b/lib/grape_oas/exporter/oas3/schema.rb
@@ -180,6 +180,8 @@ module GrapeOAS
             return ref_hash unless include_metadata
 
             result = {}
+            result["type"] = schema.type if schema.type
+            result["format"] = schema.format if schema.format
             result["description"] = schema.description.to_s if schema.description
             result["default"] = schema.default unless schema.default.nil?
             result["enum"] = schema.enum if schema.enum

--- a/lib/grape_oas/exporter/oas3/schema.rb
+++ b/lib/grape_oas/exporter/oas3/schema.rb
@@ -116,6 +116,7 @@ module GrapeOAS
           result["description"] = @schema.description.to_s if @schema.description
           result["default"] = @schema.default unless @schema.default.nil?
           result["enum"] = normalize_enum(@schema.enum, result["type"]) if @schema.enum
+          sanitize_enum_against_type(result)
           apply_all_constraints(result)
           result.merge!(@schema.extensions) if @schema.extensions
         end

--- a/test/grape_oas/exporter/oas2_schema_test.rb
+++ b/test/grape_oas/exporter/oas2_schema_test.rb
@@ -372,6 +372,28 @@ module GrapeOAS
         assert_equal [{ "type" => "string" }], result["x-oneOf"]
       end
 
+      def test_first_of_schema_ref_with_default_wraps_in_allof
+        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity")
+        schema = ApiModel::Schema.new(one_of: [ref_schema])
+        schema.default = "guest"
+
+        result = OAS2::Schema.new(schema, Set.new).build
+
+        assert_equal [{ "$ref" => "#/definitions/MyEntity" }], result["allOf"]
+        assert_equal "guest", result["default"]
+        refute result.key?("$ref"), "$ref should not be a bare sibling"
+      end
+
+      def test_first_of_schema_ref_without_attributes_stays_plain
+        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity")
+        schema = ApiModel::Schema.new(one_of: [ref_schema])
+
+        result = OAS2::Schema.new(schema, Set.new).build
+
+        assert_equal "#/definitions/MyEntity", result["$ref"]
+        refute result.key?("allOf")
+      end
+
       # === $ref + allOf wrapping: default propagation tests ===
 
       def test_ref_with_default_wraps_in_allof

--- a/test/grape_oas/exporter/oas2_schema_test.rb
+++ b/test/grape_oas/exporter/oas2_schema_test.rb
@@ -254,6 +254,49 @@ module GrapeOAS
         assert_equal "custom", result["format"]
       end
 
+      # === Composition: enum normalization ===
+
+      def test_allof_schema_normalizes_integer_enum
+        child = ApiModel::Schema.new(type: "object")
+        schema = ApiModel::Schema.new(all_of: [child], type: "integer")
+        schema.enum = %w[1 2 3]
+
+        result = OAS2::Schema.new(schema).build
+
+        assert_equal [1, 2, 3], result["enum"]
+      end
+
+      # === Inline: zero-value constraints ===
+
+      def test_inline_schema_with_zero_minimum
+        schema = ApiModel::Schema.new(type: "integer")
+        schema.minimum = 0
+        schema.maximum = 100
+
+        result = OAS2::Schema.new(schema).build
+
+        assert_equal 0, result["minimum"]
+        assert_equal 100, result["maximum"]
+      end
+
+      def test_inline_schema_with_zero_min_length
+        schema = ApiModel::Schema.new(type: "string")
+        schema.min_length = 0
+
+        result = OAS2::Schema.new(schema).build
+
+        assert_equal 0, result["minLength"]
+      end
+
+      def test_inline_schema_with_zero_min_items
+        schema = ApiModel::Schema.new(type: "array", items: ApiModel::Schema.new(type: "string"))
+        schema.min_items = 0
+
+        result = OAS2::Schema.new(schema).build
+
+        assert_equal 0, result["minItems"]
+      end
+
       # === Composition: constraints propagation tests ===
 
       def test_allof_schema_with_constraints

--- a/test/grape_oas/exporter/oas2_schema_test.rb
+++ b/test/grape_oas/exporter/oas2_schema_test.rb
@@ -283,6 +283,40 @@ module GrapeOAS
         assert_equal "^[A-Z]", result["pattern"]
       end
 
+      # === $ref + allOf wrapping: extensions propagation tests ===
+
+      def test_ref_with_extensions_wraps_in_allof
+        ref_tracker = Set.new
+        ref_schema = ApiModel::Schema.new(
+          canonical_name: "MyEntity",
+          extensions: { "x-custom" => "value" },
+        )
+        parent_schema = ApiModel::Schema.new(type: "object")
+        parent_schema.add_property("child", ref_schema)
+
+        result = OAS2::Schema.new(parent_schema, ref_tracker).build
+
+        child = result["properties"]["child"]
+
+        assert_equal [{ "$ref" => "#/definitions/MyEntity" }], child["allOf"]
+        assert_equal "value", child["x-custom"]
+      end
+
+      # === Composition: extensions propagation tests ===
+
+      def test_allof_schema_with_extensions
+        child = ApiModel::Schema.new(type: "object")
+        schema = ApiModel::Schema.new(
+          all_of: [child],
+          extensions: { "x-custom" => "allof-value" },
+        )
+
+        result = OAS2::Schema.new(schema).build
+
+        assert result.key?("allOf")
+        assert_equal "allof-value", result["x-custom"]
+      end
+
       # === $ref + allOf wrapping: default propagation tests ===
 
       def test_ref_with_default_wraps_in_allof

--- a/test/grape_oas/exporter/oas2_schema_test.rb
+++ b/test/grape_oas/exporter/oas2_schema_test.rb
@@ -291,6 +291,38 @@ module GrapeOAS
         refute child.key?("$ref")
       end
 
+      # === $ref + allOf wrapping: format and type propagation tests ===
+
+      def test_ref_with_format_wraps_in_allof
+        ref_tracker = Set.new
+        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity")
+        ref_schema.format = "date-time"
+        parent_schema = ApiModel::Schema.new(type: "object")
+        parent_schema.add_property("child", ref_schema)
+
+        result = OAS2::Schema.new(parent_schema, ref_tracker).build
+
+        child = result["properties"]["child"]
+
+        assert_equal [{ "$ref" => "#/definitions/MyEntity" }], child["allOf"]
+        assert_equal "date-time", child["format"]
+        refute child.key?("$ref")
+      end
+
+      def test_ref_with_type_wraps_in_allof
+        ref_tracker = Set.new
+        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity", type: "string")
+        parent_schema = ApiModel::Schema.new(type: "object")
+        parent_schema.add_property("child", ref_schema)
+
+        result = OAS2::Schema.new(parent_schema, ref_tracker).build
+
+        child = result["properties"]["child"]
+
+        assert_equal [{ "$ref" => "#/definitions/MyEntity" }], child["allOf"]
+        assert_equal "string", child["type"]
+      end
+
       # === Array items: description/nullable hoisting tests ===
 
       def test_array_ref_items_description_hoisted_to_outer_array

--- a/test/grape_oas/exporter/oas2_schema_test.rb
+++ b/test/grape_oas/exporter/oas2_schema_test.rb
@@ -250,6 +250,24 @@ module GrapeOAS
         assert_equal false, child["default"] # rubocop:disable Minitest/RefuteFalse
       end
 
+      # === $ref + allOf wrapping: enum propagation tests ===
+
+      def test_ref_with_enum_wraps_in_allof
+        ref_tracker = Set.new
+        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity")
+        ref_schema.enum = %w[admin user guest]
+        parent_schema = ApiModel::Schema.new(type: "object")
+        parent_schema.add_property("child", ref_schema)
+
+        result = OAS2::Schema.new(parent_schema, ref_tracker).build
+
+        child = result["properties"]["child"]
+
+        assert_equal [{ "$ref" => "#/definitions/MyEntity" }], child["allOf"]
+        assert_equal %w[admin user guest], child["enum"]
+        refute child.key?("$ref")
+      end
+
       # === Array items: description/nullable hoisting tests ===
 
       def test_array_ref_items_description_hoisted_to_outer_array

--- a/test/grape_oas/exporter/oas2_schema_test.rb
+++ b/test/grape_oas/exporter/oas2_schema_test.rb
@@ -240,6 +240,20 @@ module GrapeOAS
         assert_equal %w[x y], result["enum"]
       end
 
+      # === Composition: format and type propagation tests ===
+
+      def test_allof_schema_with_type_and_format
+        child = ApiModel::Schema.new(type: "object")
+        schema = ApiModel::Schema.new(all_of: [child], type: "object")
+        schema.format = "custom"
+
+        result = OAS2::Schema.new(schema).build
+
+        assert result.key?("allOf")
+        assert_equal "object", result["type"]
+        assert_equal "custom", result["format"]
+      end
+
       # === $ref + allOf wrapping: default propagation tests ===
 
       def test_ref_with_default_wraps_in_allof

--- a/test/grape_oas/exporter/oas2_schema_test.rb
+++ b/test/grape_oas/exporter/oas2_schema_test.rb
@@ -360,6 +360,18 @@ module GrapeOAS
         assert_equal "allof-value", result["x-custom"]
       end
 
+      def test_first_of_schema_with_extensions
+        variant = ApiModel::Schema.new(type: "string")
+        schema = ApiModel::Schema.new(
+          one_of: [variant],
+          extensions: { "x-oneOf" => [{ "type" => "string" }] },
+        )
+
+        result = OAS2::Schema.new(schema).build
+
+        assert_equal [{ "type" => "string" }], result["x-oneOf"]
+      end
+
       # === $ref + allOf wrapping: default propagation tests ===
 
       def test_ref_with_default_wraps_in_allof

--- a/test/grape_oas/exporter/oas2_schema_test.rb
+++ b/test/grape_oas/exporter/oas2_schema_test.rb
@@ -185,6 +185,38 @@ module GrapeOAS
         refute child.key?("$ref")
       end
 
+      # === Composition: default propagation tests ===
+
+      def test_allof_schema_with_default
+        child = ApiModel::Schema.new(type: "object")
+        schema = ApiModel::Schema.new(all_of: [child])
+        schema.default = { "role" => "guest" }
+
+        result = OAS2::Schema.new(schema).build
+
+        assert result.key?("allOf")
+        assert_equal({ "role" => "guest" }, result["default"])
+      end
+
+      def test_first_of_schema_with_default
+        variant = ApiModel::Schema.new(type: "string")
+        schema = ApiModel::Schema.new(one_of: [variant])
+        schema.default = "option_a"
+
+        result = OAS2::Schema.new(schema).build
+
+        assert_equal "option_a", result["default"]
+      end
+
+      def test_allof_schema_without_default
+        child = ApiModel::Schema.new(type: "object")
+        schema = ApiModel::Schema.new(all_of: [child])
+
+        result = OAS2::Schema.new(schema).build
+
+        refute result.key?("default")
+      end
+
       # === $ref + allOf wrapping: default propagation tests ===
 
       def test_ref_with_default_wraps_in_allof

--- a/test/grape_oas/exporter/oas2_schema_test.rb
+++ b/test/grape_oas/exporter/oas2_schema_test.rb
@@ -337,6 +337,61 @@ module GrapeOAS
         assert_equal "string", child["type"]
       end
 
+      # === $ref + allOf wrapping: constraints propagation tests ===
+
+      def test_ref_with_numeric_constraints_wraps_in_allof
+        ref_tracker = Set.new
+        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity")
+        ref_schema.minimum = 0
+        ref_schema.maximum = 100
+        parent_schema = ApiModel::Schema.new(type: "object")
+        parent_schema.add_property("child", ref_schema)
+
+        result = OAS2::Schema.new(parent_schema, ref_tracker).build
+
+        child = result["properties"]["child"]
+
+        assert_equal [{ "$ref" => "#/definitions/MyEntity" }], child["allOf"]
+        assert_equal 0, child["minimum"]
+        assert_equal 100, child["maximum"]
+      end
+
+      def test_ref_with_string_constraints_wraps_in_allof
+        ref_tracker = Set.new
+        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity")
+        ref_schema.min_length = 1
+        ref_schema.max_length = 255
+        ref_schema.pattern = "^[a-z]+$"
+        parent_schema = ApiModel::Schema.new(type: "object")
+        parent_schema.add_property("child", ref_schema)
+
+        result = OAS2::Schema.new(parent_schema, ref_tracker).build
+
+        child = result["properties"]["child"]
+
+        assert_equal [{ "$ref" => "#/definitions/MyEntity" }], child["allOf"]
+        assert_equal 1, child["minLength"]
+        assert_equal 255, child["maxLength"]
+        assert_equal "^[a-z]+$", child["pattern"]
+      end
+
+      def test_ref_with_array_constraints_wraps_in_allof
+        ref_tracker = Set.new
+        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity")
+        ref_schema.min_items = 1
+        ref_schema.max_items = 10
+        parent_schema = ApiModel::Schema.new(type: "object")
+        parent_schema.add_property("child", ref_schema)
+
+        result = OAS2::Schema.new(parent_schema, ref_tracker).build
+
+        child = result["properties"]["child"]
+
+        assert_equal [{ "$ref" => "#/definitions/MyEntity" }], child["allOf"]
+        assert_equal 1, child["minItems"]
+        assert_equal 10, child["maxItems"]
+      end
+
       # === Array items: description/nullable hoisting tests ===
 
       def test_array_ref_items_description_hoisted_to_outer_array

--- a/test/grape_oas/exporter/oas2_schema_test.rb
+++ b/test/grape_oas/exporter/oas2_schema_test.rb
@@ -217,6 +217,29 @@ module GrapeOAS
         refute result.key?("default")
       end
 
+      # === Composition: enum propagation tests ===
+
+      def test_allof_schema_with_enum
+        child = ApiModel::Schema.new(type: "object")
+        schema = ApiModel::Schema.new(all_of: [child])
+        schema.enum = %w[a b c]
+
+        result = OAS2::Schema.new(schema).build
+
+        assert result.key?("allOf")
+        assert_equal %w[a b c], result["enum"]
+      end
+
+      def test_first_of_schema_with_enum
+        variant = ApiModel::Schema.new(type: "string")
+        schema = ApiModel::Schema.new(one_of: [variant])
+        schema.enum = %w[x y]
+
+        result = OAS2::Schema.new(schema).build
+
+        assert_equal %w[x y], result["enum"]
+      end
+
       # === $ref + allOf wrapping: default propagation tests ===
 
       def test_ref_with_default_wraps_in_allof

--- a/test/grape_oas/exporter/oas2_schema_test.rb
+++ b/test/grape_oas/exporter/oas2_schema_test.rb
@@ -185,6 +185,39 @@ module GrapeOAS
         refute child.key?("$ref")
       end
 
+      # === $ref + allOf wrapping: default propagation tests ===
+
+      def test_ref_with_default_wraps_in_allof
+        ref_tracker = Set.new
+        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity")
+        ref_schema.default = "guest"
+        parent_schema = ApiModel::Schema.new(type: "object")
+        parent_schema.add_property("child", ref_schema)
+
+        result = OAS2::Schema.new(parent_schema, ref_tracker).build
+
+        child = result["properties"]["child"]
+
+        assert_equal [{ "$ref" => "#/definitions/MyEntity" }], child["allOf"]
+        assert_equal "guest", child["default"]
+        refute child.key?("$ref")
+      end
+
+      def test_ref_with_false_default_wraps_in_allof
+        ref_tracker = Set.new
+        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity")
+        ref_schema.default = false
+        parent_schema = ApiModel::Schema.new(type: "object")
+        parent_schema.add_property("child", ref_schema)
+
+        result = OAS2::Schema.new(parent_schema, ref_tracker).build
+
+        child = result["properties"]["child"]
+
+        assert_equal [{ "$ref" => "#/definitions/MyEntity" }], child["allOf"]
+        assert_equal false, child["default"] # rubocop:disable Minitest/RefuteFalse
+      end
+
       # === Array items: description/nullable hoisting tests ===
 
       def test_array_ref_items_description_hoisted_to_outer_array

--- a/test/grape_oas/exporter/oas2_schema_test.rb
+++ b/test/grape_oas/exporter/oas2_schema_test.rb
@@ -254,6 +254,35 @@ module GrapeOAS
         assert_equal "custom", result["format"]
       end
 
+      # === Composition: constraints propagation tests ===
+
+      def test_allof_schema_with_constraints
+        child = ApiModel::Schema.new(type: "object")
+        schema = ApiModel::Schema.new(all_of: [child])
+        schema.minimum = 0
+        schema.maximum = 100
+        schema.min_length = 1
+
+        result = OAS2::Schema.new(schema).build
+
+        assert result.key?("allOf")
+        assert_equal 0, result["minimum"]
+        assert_equal 100, result["maximum"]
+        assert_equal 1, result["minLength"]
+      end
+
+      def test_first_of_schema_with_constraints
+        variant = ApiModel::Schema.new(type: "string")
+        schema = ApiModel::Schema.new(one_of: [variant])
+        schema.min_length = 5
+        schema.pattern = "^[A-Z]"
+
+        result = OAS2::Schema.new(schema).build
+
+        assert_equal 5, result["minLength"]
+        assert_equal "^[A-Z]", result["pattern"]
+      end
+
       # === $ref + allOf wrapping: default propagation tests ===
 
       def test_ref_with_default_wraps_in_allof

--- a/test/grape_oas/exporter/oas2_schema_test.rb
+++ b/test/grape_oas/exporter/oas2_schema_test.rb
@@ -198,14 +198,14 @@ module GrapeOAS
         assert_equal({ "role" => "guest" }, result["default"])
       end
 
-      def test_first_of_schema_with_default
+      def test_first_of_schema_omits_default
         variant = ApiModel::Schema.new(type: "string")
         schema = ApiModel::Schema.new(one_of: [variant])
         schema.default = "option_a"
 
         result = OAS2::Schema.new(schema).build
 
-        assert_equal "option_a", result["default"]
+        refute result.key?("default"), "default belongs to the composition, not the fallback branch"
       end
 
       def test_allof_schema_without_default
@@ -230,14 +230,14 @@ module GrapeOAS
         assert_equal %w[a b c], result["enum"]
       end
 
-      def test_first_of_schema_with_enum
+      def test_first_of_schema_omits_enum
         variant = ApiModel::Schema.new(type: "string")
         schema = ApiModel::Schema.new(one_of: [variant])
         schema.enum = %w[x y]
 
         result = OAS2::Schema.new(schema).build
 
-        assert_equal %w[x y], result["enum"]
+        refute result.key?("enum"), "enum belongs to the composition, not the fallback branch"
       end
 
       # === Composition: format and type propagation tests ===
@@ -314,7 +314,7 @@ module GrapeOAS
         assert_equal 1, result["minLength"]
       end
 
-      def test_first_of_schema_with_constraints
+      def test_first_of_schema_omits_constraints
         variant = ApiModel::Schema.new(type: "string")
         schema = ApiModel::Schema.new(one_of: [variant])
         schema.min_length = 5
@@ -322,8 +322,8 @@ module GrapeOAS
 
         result = OAS2::Schema.new(schema).build
 
-        assert_equal 5, result["minLength"]
-        assert_equal "^[A-Z]", result["pattern"]
+        refute result.key?("minLength"), "constraints belong to the composition, not the fallback branch"
+        refute result.key?("pattern")
       end
 
       # === $ref + allOf wrapping: extensions propagation tests ===
@@ -372,16 +372,15 @@ module GrapeOAS
         assert_equal [{ "type" => "string" }], result["x-oneOf"]
       end
 
-      def test_first_of_schema_ref_with_default_wraps_in_allof
+      def test_first_of_schema_ref_with_default_stays_plain
         ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity")
         schema = ApiModel::Schema.new(one_of: [ref_schema])
         schema.default = "guest"
 
         result = OAS2::Schema.new(schema, Set.new).build
 
-        assert_equal [{ "$ref" => "#/definitions/MyEntity" }], result["allOf"]
-        assert_equal "guest", result["default"]
-        refute result.key?("$ref"), "$ref should not be a bare sibling"
+        assert_equal "#/definitions/MyEntity", result["$ref"]
+        refute result.key?("default"), "default belongs to the composition, not the fallback branch"
       end
 
       def test_first_of_schema_ref_without_attributes_stays_plain

--- a/test/grape_oas/exporter/oas2_schema_test.rb
+++ b/test/grape_oas/exporter/oas2_schema_test.rb
@@ -368,38 +368,6 @@ module GrapeOAS
         refute child.key?("$ref")
       end
 
-      # === $ref + allOf wrapping: format and type propagation tests ===
-
-      def test_ref_with_format_wraps_in_allof
-        ref_tracker = Set.new
-        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity")
-        ref_schema.format = "date-time"
-        parent_schema = ApiModel::Schema.new(type: "object")
-        parent_schema.add_property("child", ref_schema)
-
-        result = OAS2::Schema.new(parent_schema, ref_tracker).build
-
-        child = result["properties"]["child"]
-
-        assert_equal [{ "$ref" => "#/definitions/MyEntity" }], child["allOf"]
-        assert_equal "date-time", child["format"]
-        refute child.key?("$ref")
-      end
-
-      def test_ref_with_type_wraps_in_allof
-        ref_tracker = Set.new
-        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity", type: "string")
-        parent_schema = ApiModel::Schema.new(type: "object")
-        parent_schema.add_property("child", ref_schema)
-
-        result = OAS2::Schema.new(parent_schema, ref_tracker).build
-
-        child = result["properties"]["child"]
-
-        assert_equal [{ "$ref" => "#/definitions/MyEntity" }], child["allOf"]
-        assert_equal "string", child["type"]
-      end
-
       # === $ref + allOf wrapping: constraints propagation tests ===
 
       def test_ref_with_numeric_constraints_wraps_in_allof

--- a/test/grape_oas/exporter/oas3_schema_test.rb
+++ b/test/grape_oas/exporter/oas3_schema_test.rb
@@ -440,6 +440,53 @@ module GrapeOAS
         assert_equal "^[a-z]+$", result["pattern"]
       end
 
+      # === $ref + allOf wrapping: extensions propagation tests ===
+
+      def test_ref_with_extensions_wraps_in_allof
+        ref_tracker = Set.new
+        ref_schema = ApiModel::Schema.new(
+          canonical_name: "MyEntity",
+          extensions: { "x-custom" => "value" },
+        )
+        parent_schema = ApiModel::Schema.new(type: "object")
+        parent_schema.add_property("child", ref_schema)
+
+        result = OAS3::Schema.new(parent_schema, ref_tracker).build
+
+        child = result["properties"]["child"]
+
+        assert_equal [{ "$ref" => "#/components/schemas/MyEntity" }], child["allOf"]
+        assert_equal "value", child["x-custom"]
+      end
+
+      # === Composition: extensions propagation tests ===
+
+      def test_allof_schema_with_extensions
+        child = ApiModel::Schema.new(type: "object")
+        schema = ApiModel::Schema.new(
+          all_of: [child],
+          extensions: { "x-custom" => "allof-value" },
+        )
+
+        result = OAS3::Schema.new(schema).build
+
+        assert result.key?("allOf")
+        assert_equal "allof-value", result["x-custom"]
+      end
+
+      def test_oneof_schema_with_extensions
+        variant = ApiModel::Schema.new(type: "string")
+        schema = ApiModel::Schema.new(
+          one_of: [variant],
+          extensions: { "x-tag" => "poly" },
+        )
+
+        result = OAS3::Schema.new(schema).build
+
+        assert result.key?("oneOf")
+        assert_equal "poly", result["x-tag"]
+      end
+
       # === $ref + allOf wrapping: default propagation tests ===
 
       def test_ref_with_default_wraps_in_allof

--- a/test/grape_oas/exporter/oas3_schema_test.rb
+++ b/test/grape_oas/exporter/oas3_schema_test.rb
@@ -524,6 +524,98 @@ module GrapeOAS
         assert_equal "uuid", child["format"]
       end
 
+      # === $ref + allOf wrapping: constraints propagation tests ===
+
+      def test_ref_with_numeric_constraints_wraps_in_allof
+        ref_tracker = Set.new
+        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity")
+        ref_schema.minimum = 0
+        ref_schema.maximum = 100
+        parent_schema = ApiModel::Schema.new(type: "object")
+        parent_schema.add_property("child", ref_schema)
+
+        result = OAS3::Schema.new(parent_schema, ref_tracker).build
+
+        child = result["properties"]["child"]
+
+        assert_equal [{ "$ref" => "#/components/schemas/MyEntity" }], child["allOf"]
+        assert_equal 0, child["minimum"]
+        assert_equal 100, child["maximum"]
+      end
+
+      def test_ref_with_string_constraints_wraps_in_allof
+        ref_tracker = Set.new
+        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity")
+        ref_schema.min_length = 1
+        ref_schema.max_length = 255
+        ref_schema.pattern = "^[a-z]+$"
+        parent_schema = ApiModel::Schema.new(type: "object")
+        parent_schema.add_property("child", ref_schema)
+
+        result = OAS3::Schema.new(parent_schema, ref_tracker).build
+
+        child = result["properties"]["child"]
+
+        assert_equal [{ "$ref" => "#/components/schemas/MyEntity" }], child["allOf"]
+        assert_equal 1, child["minLength"]
+        assert_equal 255, child["maxLength"]
+        assert_equal "^[a-z]+$", child["pattern"]
+      end
+
+      def test_ref_with_array_constraints_wraps_in_allof
+        ref_tracker = Set.new
+        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity")
+        ref_schema.min_items = 1
+        ref_schema.max_items = 10
+        parent_schema = ApiModel::Schema.new(type: "object")
+        parent_schema.add_property("child", ref_schema)
+
+        result = OAS3::Schema.new(parent_schema, ref_tracker).build
+
+        child = result["properties"]["child"]
+
+        assert_equal [{ "$ref" => "#/components/schemas/MyEntity" }], child["allOf"]
+        assert_equal 1, child["minItems"]
+        assert_equal 10, child["maxItems"]
+      end
+
+      def test_ref_with_exclusive_bounds_wraps_in_allof
+        ref_tracker = Set.new
+        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity")
+        ref_schema.minimum = 0
+        ref_schema.exclusive_minimum = true
+        ref_schema.maximum = 100
+        ref_schema.exclusive_maximum = true
+        parent_schema = ApiModel::Schema.new(type: "object")
+        parent_schema.add_property("child", ref_schema)
+
+        result = OAS3::Schema.new(parent_schema, ref_tracker).build
+
+        child = result["properties"]["child"]
+
+        assert_equal [{ "$ref" => "#/components/schemas/MyEntity" }], child["allOf"]
+        assert_equal 0, child["minimum"]
+        assert child["exclusiveMinimum"]
+        assert_equal 100, child["maximum"]
+        assert child["exclusiveMaximum"]
+      end
+
+      def test_ref_without_constraints_stays_plain
+        ref_tracker = Set.new
+        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity")
+        parent_schema = ApiModel::Schema.new(type: "object")
+        parent_schema.add_property("child", ref_schema)
+
+        result = OAS3::Schema.new(parent_schema, ref_tracker).build
+
+        child = result["properties"]["child"]
+
+        assert_equal "#/components/schemas/MyEntity", child["$ref"]
+        refute child.key?("minimum")
+        refute child.key?("minLength")
+        refute child.key?("minItems")
+      end
+
       # === Array items: description/nullable hoisting tests ===
 
       def test_array_ref_items_description_hoisted_to_outer_array

--- a/test/grape_oas/exporter/oas3_schema_test.rb
+++ b/test/grape_oas/exporter/oas3_schema_test.rb
@@ -293,6 +293,53 @@ module GrapeOAS
         refute child.key?("type")
       end
 
+      # === $ref + allOf wrapping: default propagation tests ===
+
+      def test_ref_with_default_wraps_in_allof
+        ref_tracker = Set.new
+        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity")
+        ref_schema.default = "guest"
+        parent_schema = ApiModel::Schema.new(type: "object")
+        parent_schema.add_property("child", ref_schema)
+
+        result = OAS3::Schema.new(parent_schema, ref_tracker).build
+
+        child = result["properties"]["child"]
+
+        assert_equal [{ "$ref" => "#/components/schemas/MyEntity" }], child["allOf"]
+        assert_equal "guest", child["default"]
+        refute child.key?("$ref")
+      end
+
+      def test_ref_with_false_default_wraps_in_allof
+        ref_tracker = Set.new
+        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity")
+        ref_schema.default = false
+        parent_schema = ApiModel::Schema.new(type: "object")
+        parent_schema.add_property("child", ref_schema)
+
+        result = OAS3::Schema.new(parent_schema, ref_tracker).build
+
+        child = result["properties"]["child"]
+
+        assert_equal [{ "$ref" => "#/components/schemas/MyEntity" }], child["allOf"]
+        assert_equal false, child["default"] # rubocop:disable Minitest/RefuteFalse
+      end
+
+      def test_ref_without_default_stays_plain
+        ref_tracker = Set.new
+        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity")
+        parent_schema = ApiModel::Schema.new(type: "object")
+        parent_schema.add_property("child", ref_schema)
+
+        result = OAS3::Schema.new(parent_schema, ref_tracker).build
+
+        child = result["properties"]["child"]
+
+        assert_equal "#/components/schemas/MyEntity", child["$ref"]
+        refute child.key?("default")
+      end
+
       # === Array items: description/nullable hoisting tests ===
 
       def test_array_ref_items_description_hoisted_to_outer_array

--- a/test/grape_oas/exporter/oas3_schema_test.rb
+++ b/test/grape_oas/exporter/oas3_schema_test.rb
@@ -386,6 +386,16 @@ module GrapeOAS
         assert_equal "custom", result["format"]
       end
 
+      def test_composition_with_nullable_type_array_emits_type_array
+        child = ApiModel::Schema.new(type: "object")
+        schema = ApiModel::Schema.new(one_of: [child], type: "string", nullable: true)
+
+        result = OAS3::Schema.new(schema, nil, nullable_strategy: Constants::NullableStrategy::TYPE_ARRAY).build
+
+        assert result.key?("oneOf")
+        assert_equal %w[string null], result["type"]
+      end
+
       def test_oneof_schema_with_format
         variant = ApiModel::Schema.new(type: "string")
         schema = ApiModel::Schema.new(one_of: [variant])

--- a/test/grape_oas/exporter/oas3_schema_test.rb
+++ b/test/grape_oas/exporter/oas3_schema_test.rb
@@ -624,6 +624,21 @@ module GrapeOAS
         refute child.key?("$ref")
       end
 
+      def test_ref_with_incompatible_enum_drops_enum
+        ref_tracker = Set.new
+        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity", type: "boolean")
+        ref_schema.enum = %w[true false]
+        parent_schema = ApiModel::Schema.new(type: "object")
+        parent_schema.add_property("child", ref_schema)
+
+        result = OAS3::Schema.new(parent_schema, ref_tracker).build
+
+        child = result["properties"]["child"]
+
+        assert_equal "#/components/schemas/MyEntity", child["$ref"]
+        refute child.key?("enum"), "string enum incompatible with boolean type should be dropped"
+      end
+
       def test_ref_without_enum_stays_plain
         ref_tracker = Set.new
         ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity")

--- a/test/grape_oas/exporter/oas3_schema_test.rb
+++ b/test/grape_oas/exporter/oas3_schema_test.rb
@@ -372,6 +372,31 @@ module GrapeOAS
         assert_equal %w[x y], result["enum"]
       end
 
+      # === Composition: format and type propagation tests ===
+
+      def test_allof_schema_with_type_and_format
+        child = ApiModel::Schema.new(type: "object")
+        schema = ApiModel::Schema.new(all_of: [child], type: "object")
+        schema.format = "custom"
+
+        result = OAS3::Schema.new(schema).build
+
+        assert result.key?("allOf")
+        assert_equal "object", result["type"]
+        assert_equal "custom", result["format"]
+      end
+
+      def test_oneof_schema_with_format
+        variant = ApiModel::Schema.new(type: "string")
+        schema = ApiModel::Schema.new(one_of: [variant])
+        schema.format = "date-time"
+
+        result = OAS3::Schema.new(schema).build
+
+        assert result.key?("oneOf")
+        assert_equal "date-time", result["format"]
+      end
+
       # === $ref + allOf wrapping: default propagation tests ===
 
       def test_ref_with_default_wraps_in_allof

--- a/test/grape_oas/exporter/oas3_schema_test.rb
+++ b/test/grape_oas/exporter/oas3_schema_test.rb
@@ -337,6 +337,41 @@ module GrapeOAS
         refute result.key?("default")
       end
 
+      # === Composition: enum propagation tests ===
+
+      def test_allof_schema_with_enum
+        child = ApiModel::Schema.new(type: "object")
+        schema = ApiModel::Schema.new(all_of: [child])
+        schema.enum = %w[a b c]
+
+        result = OAS3::Schema.new(schema).build
+
+        assert result.key?("allOf")
+        assert_equal %w[a b c], result["enum"]
+      end
+
+      def test_oneof_schema_with_enum
+        variant = ApiModel::Schema.new(type: "string")
+        schema = ApiModel::Schema.new(one_of: [variant])
+        schema.enum = %w[x y]
+
+        result = OAS3::Schema.new(schema).build
+
+        assert result.key?("oneOf")
+        assert_equal %w[x y], result["enum"]
+      end
+
+      def test_anyof_schema_with_enum
+        variant = ApiModel::Schema.new(type: "string")
+        schema = ApiModel::Schema.new(any_of: [variant])
+        schema.enum = %w[x y]
+
+        result = OAS3::Schema.new(schema).build
+
+        assert result.key?("anyOf")
+        assert_equal %w[x y], result["enum"]
+      end
+
       # === $ref + allOf wrapping: default propagation tests ===
 
       def test_ref_with_default_wraps_in_allof

--- a/test/grape_oas/exporter/oas3_schema_test.rb
+++ b/test/grape_oas/exporter/oas3_schema_test.rb
@@ -535,6 +535,19 @@ module GrapeOAS
         assert_equal "poly", result["x-tag"]
       end
 
+      def test_anyof_schema_with_extensions
+        variant = ApiModel::Schema.new(type: "string")
+        schema = ApiModel::Schema.new(
+          any_of: [variant],
+          extensions: { "x-tag" => "poly" },
+        )
+
+        result = OAS3::Schema.new(schema).build
+
+        assert result.key?("anyOf")
+        assert_equal "poly", result["x-tag"]
+      end
+
       # === $ref + allOf wrapping: default propagation tests ===
 
       def test_ref_with_default_wraps_in_allof

--- a/test/grape_oas/exporter/oas3_schema_test.rb
+++ b/test/grape_oas/exporter/oas3_schema_test.rb
@@ -451,6 +451,54 @@ module GrapeOAS
         refute child.key?("enum")
       end
 
+      # === $ref + allOf wrapping: format and type propagation tests ===
+
+      def test_ref_with_format_wraps_in_allof
+        ref_tracker = Set.new
+        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity")
+        ref_schema.format = "date-time"
+        parent_schema = ApiModel::Schema.new(type: "object")
+        parent_schema.add_property("child", ref_schema)
+
+        result = OAS3::Schema.new(parent_schema, ref_tracker).build
+
+        child = result["properties"]["child"]
+
+        assert_equal [{ "$ref" => "#/components/schemas/MyEntity" }], child["allOf"]
+        assert_equal "date-time", child["format"]
+        refute child.key?("$ref")
+      end
+
+      def test_ref_with_type_wraps_in_allof
+        ref_tracker = Set.new
+        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity", type: "string")
+        parent_schema = ApiModel::Schema.new(type: "object")
+        parent_schema.add_property("child", ref_schema)
+
+        result = OAS3::Schema.new(parent_schema, ref_tracker).build
+
+        child = result["properties"]["child"]
+
+        assert_equal [{ "$ref" => "#/components/schemas/MyEntity" }], child["allOf"]
+        assert_equal "string", child["type"]
+      end
+
+      def test_ref_with_type_and_format_wraps_in_allof
+        ref_tracker = Set.new
+        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity", type: "string")
+        ref_schema.format = "uuid"
+        parent_schema = ApiModel::Schema.new(type: "object")
+        parent_schema.add_property("child", ref_schema)
+
+        result = OAS3::Schema.new(parent_schema, ref_tracker).build
+
+        child = result["properties"]["child"]
+
+        assert_equal [{ "$ref" => "#/components/schemas/MyEntity" }], child["allOf"]
+        assert_equal "string", child["type"]
+        assert_equal "uuid", child["format"]
+      end
+
       # === Array items: description/nullable hoisting tests ===
 
       def test_array_ref_items_description_hoisted_to_outer_array

--- a/test/grape_oas/exporter/oas3_schema_test.rb
+++ b/test/grape_oas/exporter/oas3_schema_test.rb
@@ -488,6 +488,17 @@ module GrapeOAS
         assert_equal [1, 2, 3], result["enum"]
       end
 
+      def test_allof_schema_sanitizes_incompatible_enum
+        child = ApiModel::Schema.new(type: "object")
+        schema = ApiModel::Schema.new(all_of: [child], type: "boolean")
+        schema.enum = %w[true false]
+
+        result = OAS3::Schema.new(schema).build
+
+        assert result.key?("allOf")
+        refute result.key?("enum"), "string enum incompatible with boolean type should be dropped"
+      end
+
       # === $ref + allOf wrapping: extensions propagation tests ===
 
       def test_ref_with_extensions_wraps_in_allof

--- a/test/grape_oas/exporter/oas3_schema_test.rb
+++ b/test/grape_oas/exporter/oas3_schema_test.rb
@@ -384,6 +384,38 @@ module GrapeOAS
         refute child.key?("default")
       end
 
+      # === $ref + allOf wrapping: enum propagation tests ===
+
+      def test_ref_with_enum_wraps_in_allof
+        ref_tracker = Set.new
+        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity")
+        ref_schema.enum = %w[admin user guest]
+        parent_schema = ApiModel::Schema.new(type: "object")
+        parent_schema.add_property("child", ref_schema)
+
+        result = OAS3::Schema.new(parent_schema, ref_tracker).build
+
+        child = result["properties"]["child"]
+
+        assert_equal [{ "$ref" => "#/components/schemas/MyEntity" }], child["allOf"]
+        assert_equal %w[admin user guest], child["enum"]
+        refute child.key?("$ref")
+      end
+
+      def test_ref_without_enum_stays_plain
+        ref_tracker = Set.new
+        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity")
+        parent_schema = ApiModel::Schema.new(type: "object")
+        parent_schema.add_property("child", ref_schema)
+
+        result = OAS3::Schema.new(parent_schema, ref_tracker).build
+
+        child = result["properties"]["child"]
+
+        assert_equal "#/components/schemas/MyEntity", child["$ref"]
+        refute child.key?("enum")
+      end
+
       # === Array items: description/nullable hoisting tests ===
 
       def test_array_ref_items_description_hoisted_to_outer_array

--- a/test/grape_oas/exporter/oas3_schema_test.rb
+++ b/test/grape_oas/exporter/oas3_schema_test.rb
@@ -566,54 +566,6 @@ module GrapeOAS
         refute child.key?("enum")
       end
 
-      # === $ref + allOf wrapping: format and type propagation tests ===
-
-      def test_ref_with_format_wraps_in_allof
-        ref_tracker = Set.new
-        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity")
-        ref_schema.format = "date-time"
-        parent_schema = ApiModel::Schema.new(type: "object")
-        parent_schema.add_property("child", ref_schema)
-
-        result = OAS3::Schema.new(parent_schema, ref_tracker).build
-
-        child = result["properties"]["child"]
-
-        assert_equal [{ "$ref" => "#/components/schemas/MyEntity" }], child["allOf"]
-        assert_equal "date-time", child["format"]
-        refute child.key?("$ref")
-      end
-
-      def test_ref_with_type_wraps_in_allof
-        ref_tracker = Set.new
-        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity", type: "string")
-        parent_schema = ApiModel::Schema.new(type: "object")
-        parent_schema.add_property("child", ref_schema)
-
-        result = OAS3::Schema.new(parent_schema, ref_tracker).build
-
-        child = result["properties"]["child"]
-
-        assert_equal [{ "$ref" => "#/components/schemas/MyEntity" }], child["allOf"]
-        assert_equal "string", child["type"]
-      end
-
-      def test_ref_with_type_and_format_wraps_in_allof
-        ref_tracker = Set.new
-        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity", type: "string")
-        ref_schema.format = "uuid"
-        parent_schema = ApiModel::Schema.new(type: "object")
-        parent_schema.add_property("child", ref_schema)
-
-        result = OAS3::Schema.new(parent_schema, ref_tracker).build
-
-        child = result["properties"]["child"]
-
-        assert_equal [{ "$ref" => "#/components/schemas/MyEntity" }], child["allOf"]
-        assert_equal "string", child["type"]
-        assert_equal "uuid", child["format"]
-      end
-
       # === $ref + allOf wrapping: constraints propagation tests ===
 
       def test_ref_with_numeric_constraints_wraps_in_allof

--- a/test/grape_oas/exporter/oas3_schema_test.rb
+++ b/test/grape_oas/exporter/oas3_schema_test.rb
@@ -440,6 +440,54 @@ module GrapeOAS
         assert_equal "^[a-z]+$", result["pattern"]
       end
 
+      # === Composition: exclusive bounds under TYPE_ARRAY strategy ===
+
+      def test_allof_schema_with_exclusive_bounds_type_array
+        child = ApiModel::Schema.new(type: "object")
+        schema = ApiModel::Schema.new(all_of: [child])
+        schema.minimum = 0
+        schema.exclusive_minimum = true
+        schema.maximum = 100
+        schema.exclusive_maximum = true
+
+        result = OAS3::Schema.new(schema, nil, nullable_strategy: Constants::NullableStrategy::TYPE_ARRAY).build
+
+        assert result.key?("allOf")
+        assert_equal 0, result["exclusiveMinimum"]
+        assert_equal 100, result["exclusiveMaximum"]
+        refute result.key?("minimum")
+        refute result.key?("maximum")
+      end
+
+      def test_ref_with_exclusive_bounds_type_array
+        ref_tracker = Set.new
+        ref_schema = ApiModel::Schema.new(canonical_name: "MyEntity")
+        ref_schema.minimum = 5
+        ref_schema.exclusive_minimum = true
+        parent_schema = ApiModel::Schema.new(type: "object")
+        parent_schema.add_property("child", ref_schema)
+
+        result = OAS3::Schema.new(parent_schema, ref_tracker, nullable_strategy: Constants::NullableStrategy::TYPE_ARRAY).build
+
+        child = result["properties"]["child"]
+
+        assert_equal [{ "$ref" => "#/components/schemas/MyEntity" }], child["allOf"]
+        assert_equal 5, child["exclusiveMinimum"]
+        refute child.key?("minimum")
+      end
+
+      # === Composition: enum normalization ===
+
+      def test_allof_schema_normalizes_integer_enum
+        child = ApiModel::Schema.new(type: "object")
+        schema = ApiModel::Schema.new(all_of: [child], type: "integer")
+        schema.enum = %w[1 2 3]
+
+        result = OAS3::Schema.new(schema).build
+
+        assert_equal [1, 2, 3], result["enum"]
+      end
+
       # === $ref + allOf wrapping: extensions propagation tests ===
 
       def test_ref_with_extensions_wraps_in_allof

--- a/test/grape_oas/exporter/oas3_schema_test.rb
+++ b/test/grape_oas/exporter/oas3_schema_test.rb
@@ -293,6 +293,50 @@ module GrapeOAS
         refute child.key?("type")
       end
 
+      # === Composition: default propagation tests ===
+
+      def test_allof_schema_with_default
+        child = ApiModel::Schema.new(type: "object")
+        schema = ApiModel::Schema.new(all_of: [child])
+        schema.default = { "role" => "guest" }
+
+        result = OAS3::Schema.new(schema).build
+
+        assert result.key?("allOf")
+        assert_equal({ "role" => "guest" }, result["default"])
+      end
+
+      def test_oneof_schema_with_default
+        variant = ApiModel::Schema.new(type: "string")
+        schema = ApiModel::Schema.new(one_of: [variant])
+        schema.default = "option_a"
+
+        result = OAS3::Schema.new(schema).build
+
+        assert result.key?("oneOf")
+        assert_equal "option_a", result["default"]
+      end
+
+      def test_anyof_schema_with_default
+        variant = ApiModel::Schema.new(type: "string")
+        schema = ApiModel::Schema.new(any_of: [variant])
+        schema.default = "option_a"
+
+        result = OAS3::Schema.new(schema).build
+
+        assert result.key?("anyOf")
+        assert_equal "option_a", result["default"]
+      end
+
+      def test_allof_schema_without_default
+        child = ApiModel::Schema.new(type: "object")
+        schema = ApiModel::Schema.new(all_of: [child])
+
+        result = OAS3::Schema.new(schema).build
+
+        refute result.key?("default")
+      end
+
       # === $ref + allOf wrapping: default propagation tests ===
 
       def test_ref_with_default_wraps_in_allof

--- a/test/grape_oas/exporter/oas3_schema_test.rb
+++ b/test/grape_oas/exporter/oas3_schema_test.rb
@@ -397,6 +397,49 @@ module GrapeOAS
         assert_equal "date-time", result["format"]
       end
 
+      # === Composition: constraints propagation tests ===
+
+      def test_allof_schema_with_constraints
+        child = ApiModel::Schema.new(type: "object")
+        schema = ApiModel::Schema.new(all_of: [child])
+        schema.minimum = 0
+        schema.maximum = 100
+        schema.min_length = 1
+        schema.max_length = 50
+
+        result = OAS3::Schema.new(schema).build
+
+        assert result.key?("allOf")
+        assert_equal 0, result["minimum"]
+        assert_equal 100, result["maximum"]
+        assert_equal 1, result["minLength"]
+        assert_equal 50, result["maxLength"]
+      end
+
+      def test_oneof_schema_with_constraints
+        variant = ApiModel::Schema.new(type: "string")
+        schema = ApiModel::Schema.new(one_of: [variant])
+        schema.min_items = 1
+        schema.max_items = 5
+
+        result = OAS3::Schema.new(schema).build
+
+        assert result.key?("oneOf")
+        assert_equal 1, result["minItems"]
+        assert_equal 5, result["maxItems"]
+      end
+
+      def test_anyof_schema_with_pattern
+        variant = ApiModel::Schema.new(type: "string")
+        schema = ApiModel::Schema.new(any_of: [variant])
+        schema.pattern = "^[a-z]+$"
+
+        result = OAS3::Schema.new(schema).build
+
+        assert result.key?("anyOf")
+        assert_equal "^[a-z]+$", result["pattern"]
+      end
+
       # === $ref + allOf wrapping: default propagation tests ===
 
       def test_ref_with_default_wraps_in_allof

--- a/test/grape_oas/exporter/oas3_schema_test.rb
+++ b/test/grape_oas/exporter/oas3_schema_test.rb
@@ -719,6 +719,36 @@ module GrapeOAS
         refute child.key?("minItems")
       end
 
+      # === $ref + allOf wrapping: combined attributes test ===
+
+      def test_ref_with_multiple_attributes_wraps_in_allof
+        ref_tracker = Set.new
+        ref_schema = ApiModel::Schema.new(
+          canonical_name: "MyEntity",
+          description: "A related entity",
+          extensions: { "x-deprecated" => true },
+        )
+        ref_schema.default = "guest"
+        ref_schema.enum = %w[admin user guest]
+        ref_schema.min_length = 1
+        ref_schema.max_length = 50
+        parent_schema = ApiModel::Schema.new(type: "object")
+        parent_schema.add_property("child", ref_schema)
+
+        result = OAS3::Schema.new(parent_schema, ref_tracker).build
+
+        child = result["properties"]["child"]
+
+        assert_equal [{ "$ref" => "#/components/schemas/MyEntity" }], child["allOf"]
+        assert_equal "A related entity", child["description"]
+        assert_equal "guest", child["default"]
+        assert_equal %w[admin user guest], child["enum"]
+        assert_equal 1, child["minLength"]
+        assert_equal 50, child["maxLength"]
+        assert child["x-deprecated"]
+        refute child.key?("$ref")
+      end
+
       # === Array items: description/nullable hoisting tests ===
 
       def test_array_ref_items_description_hoisted_to_outer_array


### PR DESCRIPTION
## Summary

When a schema is rendered through a `$ref` wrapper or composition path
(`allOf`/`oneOf`/`anyOf`), most attributes set on the schema instance were
silently dropped. Only `description` and `nullable` survived these paths —
everything else (`default`, `enum`, `format`, constraints, extensions) was
lost.

This was surfaced during #59 (default value export) but the limitation is
pre-existing and affects all schema attributes equally.

This PR propagates the missing attributes through both rendering paths in
OAS2 and OAS3 exporters, following the pattern already established for
`description` and `nullable`.

Additionally fixes several pre-existing issues discovered during
implementation:
- OAS2 `apply_constraints` dropped zero values (`minimum: 0`, `minLength: 0`)
  due to truthiness checks instead of `nil?` guards
- OAS3 composition and `$ref` paths skipped `sanitize_enum_against_type`,
  allowing type-incompatible enums to leak into the output
- OAS3 composition schemas lost `TYPE_ARRAY` nullability (OAS 3.1 default)
  when an explicit type was present

## What changed

**`$ref` wrappers** (`build_schema_or_ref` when `canonical_name` is present):
`default`, `enum`, constraints, and extensions are now included in the `allOf`
wrapper alongside the `$ref` — the same pattern already used for `description`
and `nullable`.

**Composition schemas** (`build_all_of_schema`, `build_one_of_schema`,
`build_any_of_schema`): `default`, `enum`, `type`, `format`, constraints, and
extensions are now emitted on the composition wrapper.

**OAS2 `build_first_of_schema`** (lossy oneOf/anyOf fallback): only
`description` and extensions are applied from the composition node.
Type-specific attributes are intentionally omitted because they describe the
multi-type composition, not the single fallback branch.

## Example

```ruby
class UserEntity < Grape::Entity
  expose :role, documentation: { type: String }
end

params do
  requires :user, type: Hash do
    optional :role, type: String, default: "guest"
  end
end
post "users" do; end
```

```yaml
# Before (default dropped on $ref-wrapped schema):
properties:
  role:
    allOf:
      - $ref: "#/components/schemas/UserEntity"
    description: "..."
    # "default" is missing

# After (default preserved in allOf wrapper):
properties:
  role:
    allOf:
      - $ref: "#/components/schemas/UserEntity"
    description: "..."
    default: "guest"
```

Constraints on `$ref` wrappers:
```yaml
# Before (constraints dropped):
properties:
  score:
    $ref: "#/components/schemas/ScoreEntity"

# After (constraints preserved in allOf wrapper):
properties:
  score:
    allOf:
      - $ref: "#/components/schemas/ScoreEntity"
    minimum: 0
    maximum: 100
```

Enum on composition schema:
```yaml
# Before (enum dropped):
oneOf:
  - $ref: "#/components/schemas/TypeA"
  - $ref: "#/components/schemas/TypeB"

# After (enum preserved on composition wrapper):
oneOf:
  - $ref: "#/components/schemas/TypeA"
  - $ref: "#/components/schemas/TypeB"
enum: ["a", "b", "c"]
```

## Attribute survival matrix (after this PR)

| Attribute | Inline | `$ref` wrap | `allOf` | `oneOf` | `anyOf` |
|---|:---:|:---:|:---:|:---:|:---:|
| `description` | yes | yes | yes | yes | yes |
| `nullable` | yes | yes | yes | yes | yes |
| `default` | yes | yes | yes | yes | yes |
| `enum` | yes | yes | yes | yes | yes |
| `format` | yes | — | yes | yes | yes |
| `type` | yes | — | yes | yes | yes |
| constraints | yes | yes | yes | yes | yes |
| `extensions` | yes | yes | yes | yes | yes |

`type` and `format` are not propagated on `$ref` wrappers because entity
schemas always carry their native type, which would cause every entity
reference to get unwanted `allOf` wrapping.

Closes #65.