### PR TITLE
Default POST success responses to 201

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#61](https://github.com/numbata/grape-oas/pull/61): Respect `entity_name` on `grape::entity` subclasses - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#68](https://github.com/numbata/grape-oas/pull/68): De-duplicate parameter `description` between the Parameter Object and its nested `schema` in OAS 3 output - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#70](https://github.com/numbata/grape-oas/pull/70): Propagate schema attributes (`default`, `enum`, constraints, extensions) through `$ref` and composition paths - [@numbata](https://github.com/numbata).
+- [#72](https://github.com/numbata/grape-oas/pull/72): Default POST success responses to 201 - [@olivier-thatch](https://github.com/olivier-thatch).
+- Your contribution here
 
 ### Changed
 

--- a/lib/grape_oas/api_model_builders/response_parsers/base.rb
+++ b/lib/grape_oas/api_model_builders/response_parsers/base.rb
@@ -50,6 +50,15 @@ module GrapeOAS
 
           hash.transform_keys { |k| k.is_a?(String) ? k.to_sym : k }
         end
+
+        # Default success status code for a route when none is explicitly provided.
+        # POST routes default to 201; all other methods default to 200.
+        # Honors an explicit `default_status:` route option.
+        def default_success_code(route)
+          return route.options[:default_status] if route.options[:default_status]
+
+          route.request_method.to_s.upcase == "POST" ? 201 : 200
+        end
       end
     end
   end

--- a/lib/grape_oas/api_model_builders/response_parsers/default_response_parser.rb
+++ b/lib/grape_oas/api_model_builders/response_parsers/default_response_parser.rb
@@ -3,8 +3,9 @@
 module GrapeOAS
   module ApiModelBuilders
     module ResponseParsers
-      # Parser that creates a default 200 response when no responses are defined
-      # This is the fallback parser used when no other parsers are applicable
+      # Parser that creates a default success response when no responses are defined.
+      # Status code defaults to 201 for POST routes and 200 for all other methods.
+      # This is the fallback parser used when no other parsers are applicable.
       class DefaultResponseParser
         include Base
 
@@ -14,12 +15,8 @@ module GrapeOAS
         end
 
         def parse(route)
-          inferred = route.options[:default_status]
-          inferred ||= route.request_method.to_s.upcase == "POST" ? 201 : 200
-          default_code = inferred.to_s
-
           [{
-            code: default_code,
+            code: default_success_code(route).to_s,
             message: "Success",
             entity: route.options[:entity],
             headers: nil

--- a/lib/grape_oas/api_model_builders/response_parsers/http_codes_parser.rb
+++ b/lib/grape_oas/api_model_builders/response_parsers/http_codes_parser.rb
@@ -96,7 +96,7 @@ module GrapeOAS
           if entity_value.is_a?(Hash)
             # Hash format: { code: 201, model: Entity, message: "Created" }
             {
-              code: entity_value[:code] || 200,
+              code: entity_value[:code] || default_success_code(route),
               message: entity_value[:message],
               entity: extract_entity(entity_value, nil),
               headers: entity_value[:headers],
@@ -109,7 +109,7 @@ module GrapeOAS
           else
             # Plain entity class
             {
-              code: 200,
+              code: default_success_code(route),
               message: nil,
               entity: entity_value,
               headers: nil,
@@ -136,7 +136,7 @@ module GrapeOAS
         end
 
         def normalize_hash_entry(entry, route)
-          default_code = (route.options[:default_status] || 200).to_s
+          default_code = default_success_code(route).to_s
           {
             code: extract_status_code(entry, default_code),
             message: extract_description(entry),
@@ -166,7 +166,7 @@ module GrapeOAS
         def normalize_entity_entry(entity_class, route)
           # Plain entity class (e.g., success TestEntity)
           {
-            code: route.options[:default_status] || 200,
+            code: default_success_code(route),
             message: nil,
             entity: entity_class,
             headers: nil,

--- a/test/grape_oas/api_model_builders/response_parsers/default_response_parser_test.rb
+++ b/test/grape_oas/api_model_builders/response_parsers/default_response_parser_test.rb
@@ -27,6 +27,60 @@ module GrapeOAS
           assert_equal "Success", specs[0][:message]
         end
 
+        def test_returns_201_for_post
+          route = mock_route
+          route.request_method = "POST"
+
+          specs = @parser.parse(route)
+
+          assert_equal "201", specs[0][:code]
+        end
+
+        def test_returns_200_for_get
+          route = mock_route
+          route.request_method = "GET"
+
+          specs = @parser.parse(route)
+
+          assert_equal "200", specs[0][:code]
+        end
+
+        def test_returns_200_for_put
+          route = mock_route
+          route.request_method = "PUT"
+
+          specs = @parser.parse(route)
+
+          assert_equal "200", specs[0][:code]
+        end
+
+        def test_returns_200_for_patch
+          route = mock_route
+          route.request_method = "PATCH"
+
+          specs = @parser.parse(route)
+
+          assert_equal "200", specs[0][:code]
+        end
+
+        def test_returns_200_for_delete
+          route = mock_route
+          route.request_method = "DELETE"
+
+          specs = @parser.parse(route)
+
+          assert_equal "200", specs[0][:code]
+        end
+
+        def test_default_status_overrides_post_inference
+          route = mock_route(default_status: 202)
+          route.request_method = "POST"
+
+          specs = @parser.parse(route)
+
+          assert_equal "202", specs[0][:code]
+        end
+
         def test_uses_custom_default_status
           route = mock_route(default_status: 201)
 
@@ -54,7 +108,7 @@ module GrapeOAS
         private
 
         def mock_route(options = {})
-          OpenStruct.new(options: options)
+          OpenStruct.new(options: options, request_method: nil)
         end
       end
     end

--- a/test/grape_oas/api_model_builders/response_parsers/http_codes_parser_desc_block_test.rb
+++ b/test/grape_oas/api_model_builders/response_parsers/http_codes_parser_desc_block_test.rb
@@ -112,10 +112,11 @@ module GrapeOAS
           mock_route(settings: { description: desc_data })
         end
 
-        def mock_route(options: {}, settings: {})
+        def mock_route(options: {}, settings: {}, request_method: "GET")
           route = Object.new
           route.define_singleton_method(:options) { options }
           route.define_singleton_method(:settings) { settings }
+          route.define_singleton_method(:request_method) { request_method }
           route
         end
       end

--- a/test/grape_oas/api_model_builders/response_parsers/http_codes_parser_desc_block_test.rb
+++ b/test/grape_oas/api_model_builders/response_parsers/http_codes_parser_desc_block_test.rb
@@ -106,6 +106,20 @@ module GrapeOAS
           assert_equal "Created", specs.first[:message]
         end
 
+        def test_desc_block_plain_entity_on_post_infers_201
+          entity = Class.new
+          route = mock_route(
+            settings: { description: { success: entity } },
+            request_method: "POST",
+          )
+
+          specs = @parser.parse(route)
+
+          assert_equal 1, specs.size
+          assert_equal 201, specs.first[:code]
+          assert_equal entity, specs.first[:entity]
+        end
+
         private
 
         def mock_route_with_desc_block(desc_data)

--- a/test/grape_oas/api_model_builders/response_parsers/http_codes_parser_test.rb
+++ b/test/grape_oas/api_model_builders/response_parsers/http_codes_parser_test.rb
@@ -259,10 +259,33 @@ module GrapeOAS
           assert specs[0][:required]
         end
 
+        def test_success_plain_entity_class_defaults_to_200_for_get
+          entity = Class.new
+          route = mock_route(success: entity)
+          route.request_method = "GET"
+
+          specs = @parser.parse(route)
+
+          assert_equal 1, specs.size
+          assert_equal 200, specs[0][:code]
+          assert_equal entity, specs[0][:entity]
+        end
+
+        def test_success_plain_entity_class_defaults_to_201_for_post
+          entity = Class.new
+          route = mock_route(success: entity)
+          route.request_method = "POST"
+
+          specs = @parser.parse(route)
+
+          assert_equal 1, specs.size
+          assert_equal 201, specs[0][:code]
+        end
+
         private
 
         def mock_route(options = {})
-          OpenStruct.new(options: options)
+          OpenStruct.new(options: options, request_method: nil)
         end
       end
     end

--- a/test/grape_oas/api_model_builders/response_test.rb
+++ b/test/grape_oas/api_model_builders/response_test.rb
@@ -106,6 +106,96 @@ module GrapeOAS
         assert_equal "TestUserEntity", schema.canonical_name
       end
 
+      def test_infers_201_for_post_without_entity
+        api_class = Class.new(Grape::API) do
+          format :json
+          post "users" do
+            {}
+          end
+        end
+
+        route = api_class.routes.first
+        response = Response.new(api: @api, route: route).build.first
+
+        assert_equal "201", response.http_status
+        assert_equal "Success", response.description
+      end
+
+      def test_infers_200_for_get_without_entity
+        api_class = Class.new(Grape::API) do
+          format :json
+          get "users" do
+            {}
+          end
+        end
+
+        route = api_class.routes.first
+        response = Response.new(api: @api, route: route).build.first
+
+        assert_equal "200", response.http_status
+      end
+
+      def test_success_entity_class_defaults_to_201_for_post
+        entity_class = Class.new(Grape::Entity)
+        api_class = Class.new(Grape::API) do
+          format :json
+          post "users", success: entity_class do
+            {}
+          end
+        end
+
+        route = api_class.routes.first
+        response = Response.new(api: @api, route: route).build.first
+
+        assert_equal "201", response.http_status
+      end
+
+      def test_success_entity_class_defaults_to_200_for_get
+        entity_class = Class.new(Grape::Entity)
+        api_class = Class.new(Grape::API) do
+          format :json
+          get "users", success: entity_class do
+            {}
+          end
+        end
+
+        route = api_class.routes.first
+        response = Response.new(api: @api, route: route).build.first
+
+        assert_equal "200", response.http_status
+      end
+
+      def test_success_entity_class_defaults_to_200_for_put
+        entity_class = Class.new(Grape::Entity)
+        api_class = Class.new(Grape::API) do
+          format :json
+          put "users/:id", success: entity_class do
+            {}
+          end
+        end
+
+        route = api_class.routes.first
+        response = Response.new(api: @api, route: route).build.first
+
+        assert_equal "200", response.http_status
+      end
+
+      def test_success_hash_with_explicit_code_is_respected_for_post
+        entity_class = Class.new(Grape::Entity)
+        api_class = Class.new(Grape::API) do
+          format :json
+          post "users", success: { code: 202, model: entity_class, message: "Accepted" } do
+            {}
+          end
+        end
+
+        route = api_class.routes.first
+        response = Response.new(api: @api, route: route).build.first
+
+        assert_equal "202", response.http_status
+        assert_equal "Accepted", response.description
+      end
+
       def test_builds_multiple_responses_from_success_and_failure
         entity_class = Class.new(Grape::Entity)
         api_class = Class.new(Grape::API) do


### PR DESCRIPTION
## Summary

- When a route only specifies a response entity (e.g. `success: Entities::Kitten`), grape-oas now infers `201` for POST routes and keeps `200` for all other HTTP methods.
- Explicit `success: { code: X, ... }` and `default_status:` still take precedence.
- Internally, the status-code inference is consolidated in a new `default_success_code` helper on the parsers' `Base` module, replacing the four hardcoded `200` defaults in `HttpCodesParser` plus the inline logic in `DefaultResponseParser`.

## Test plan

- [x] New unit tests in `default_response_parser_test.rb` covering POST→201 and GET/PUT/PATCH/DELETE→200, plus `default_status:` override
- [x] New unit tests in `http_codes_parser_test.rb` covering `success: EntityClass` for GET and POST
- [x] New integration tests in `response_test.rb` covering the POST-with-entity and explicit-code paths end-to-end
- [x] Full suite passes (1 pre-existing unrelated failure in `OptionalBigDecimalDependencyTest` remains on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)