### PR TITLE
Fix BigDecimal range bounds serializing as JSON strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [#78](https://github.com/numbata/grape-oas/pull/78): Fix: use empty schema for undocumented responses instead of `{ type: string }` - [@bogdan](https://github.com/bogdan).
+- [#74](https://github.com/numbata/grape-oas/pull/74): Fix BigDecimal range bounds serializing as JSON strings - [@olivier-thatch](https://github.com/olivier-thatch).
 * Your contribution here
 
 ### Changed
@@ -27,8 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#61](https://github.com/numbata/grape-oas/pull/61): Respect `entity_name` on `grape::entity` subclasses - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#68](https://github.com/numbata/grape-oas/pull/68): De-duplicate parameter `description` between the Parameter Object and its nested `schema` in OAS 3 output - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#70](https://github.com/numbata/grape-oas/pull/70): Propagate schema attributes (`default`, `enum`, constraints, extensions) through `$ref` and composition paths - [@numbata](https://github.com/numbata).
-- [#74](https://github.com/numbata/grape-oas/pull/74): Fix BigDecimal range bounds serializing as JSON strings - [@olivier-thatch](https://github.com/olivier-thatch).
-* Your contribution here
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#61](https://github.com/numbata/grape-oas/pull/61): Respect `entity_name` on `grape::entity` subclasses - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#68](https://github.com/numbata/grape-oas/pull/68): De-duplicate parameter `description` between the Parameter Object and its nested `schema` in OAS 3 output - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#70](https://github.com/numbata/grape-oas/pull/70): Propagate schema attributes (`default`, `enum`, constraints, extensions) through `$ref` and composition paths - [@numbata](https://github.com/numbata).
-- Your contribution here
+- [#74](https://github.com/numbata/grape-oas/pull/74): Fix BigDecimal range bounds serializing as JSON strings - [@olivier-thatch](https://github.com/olivier-thatch).
+* Your contribution here
 
 ### Changed
 

--- a/lib/grape_oas/range_utils.rb
+++ b/lib/grape_oas/range_utils.rb
@@ -34,10 +34,10 @@ module GrapeOAS
 
         return if descending?(first_val, last_val)
 
-        target.minimum = first_val if finite_numeric?(first_val) && target.respond_to?(:minimum=)
+        target.minimum = coerce_for_json(first_val) if finite_numeric?(first_val) && target.respond_to?(:minimum=)
         return unless finite_numeric?(last_val)
 
-        target.maximum = last_val if target.respond_to?(:maximum=)
+        target.maximum = coerce_for_json(last_val) if target.respond_to?(:maximum=)
         target.exclusive_maximum = range.exclude_end? if target.respond_to?(:exclusive_maximum=)
       end
 
@@ -77,6 +77,13 @@ module GrapeOAS
 
       def finite_numeric?(val)
         val.is_a?(Numeric) && val.finite?
+      end
+
+      # BigDecimal serializes to JSON as a string (e.g. "0.1e1"), violating the
+      # OpenAPI/JSON-Schema requirement that `minimum`/`maximum` be numbers.
+      # Coerce to Float so it renders as a JSON number literal.
+      def coerce_for_json(val)
+        defined?(BigDecimal) && val.is_a?(BigDecimal) ? val.to_f : val
       end
 
       def descending?(first_val, last_val)

--- a/lib/grape_oas/range_utils.rb
+++ b/lib/grape_oas/range_utils.rb
@@ -39,13 +39,13 @@ module GrapeOAS
           target.minimum = coerced_min unless coerced_min.nil?
         end
 
-        if finite_numeric?(last_val)
-          coerced_max = coerce_for_json(last_val)
-          unless coerced_max.nil?
-            target.maximum = coerced_max if target.respond_to?(:maximum=)
-            target.exclusive_maximum = range.exclude_end? if target.respond_to?(:exclusive_maximum=)
-          end
-        end
+        return unless finite_numeric?(last_val)
+
+        coerced_max = coerce_for_json(last_val)
+        return if coerced_max.nil?
+
+        target.maximum = coerced_max if target.respond_to?(:maximum=)
+        target.exclusive_maximum = range.exclude_end? if target.respond_to?(:exclusive_maximum=)
       end
 
       # Returns true when all non-nil bounds are Numeric (pure numeric range).

--- a/lib/grape_oas/range_utils.rb
+++ b/lib/grape_oas/range_utils.rb
@@ -34,11 +34,18 @@ module GrapeOAS
 
         return if descending?(first_val, last_val)
 
-        target.minimum = coerce_for_json(first_val) if finite_numeric?(first_val) && target.respond_to?(:minimum=)
-        return unless finite_numeric?(last_val)
+        if finite_numeric?(first_val) && target.respond_to?(:minimum=)
+          coerced_min = coerce_for_json(first_val)
+          target.minimum = coerced_min unless coerced_min.nil?
+        end
 
-        target.maximum = coerce_for_json(last_val) if target.respond_to?(:maximum=)
-        target.exclusive_maximum = range.exclude_end? if target.respond_to?(:exclusive_maximum=)
+        if finite_numeric?(last_val)
+          coerced_max = coerce_for_json(last_val)
+          unless coerced_max.nil?
+            target.maximum = coerced_max if target.respond_to?(:maximum=)
+            target.exclusive_maximum = range.exclude_end? if target.respond_to?(:exclusive_maximum=)
+          end
+        end
       end
 
       # Returns true when all non-nil bounds are Numeric (pure numeric range).
@@ -79,11 +86,20 @@ module GrapeOAS
         val.is_a?(Numeric) && val.finite?
       end
 
-      # BigDecimal serializes to JSON as a string (e.g. "0.1e1"), violating the
-      # OpenAPI/JSON-Schema requirement that `minimum`/`maximum` be numbers.
-      # Coerce to Float so it renders as a JSON number literal.
+      # Coerce BigDecimal to Float so min/max render as JSON numbers, not strings.
+      # Returns nil when the result overflows to Infinity.
       def coerce_for_json(val)
-        defined?(BigDecimal) && val.is_a?(BigDecimal) ? val.to_f : val
+        return val unless defined?(BigDecimal) && val.is_a?(BigDecimal)
+
+        coerced = val.to_f
+        unless coerced.finite?
+          GrapeOAS.logger.warn("BigDecimal value #{val} overflows to Float::INFINITY and cannot be represented in JSON; skipping bound")
+          return nil
+        end
+        if val != BigDecimal(coerced, Float::DIG + 1)
+          GrapeOAS.logger.debug("BigDecimal value #{val} lost precision when coerced to Float #{coerced}")
+        end
+        coerced
       end
 
       def descending?(first_val, last_val)

--- a/test/e2e/generate_bigdecimal_param_test.rb
+++ b/test/e2e/generate_bigdecimal_param_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "bigdecimal"
+require "bigdecimal/util"
+require "json"
+
+module GrapeOAS
+  class GenerateBigDecimalParamTest < Minitest::Test
+    class SampleAPI < Grape::API
+      format :json
+
+      desc "Create a forecast"
+      params do
+        optional :conversion_probability,
+                 type: BigDecimal,
+                 values: BigDecimal(0)..BigDecimal(1),
+                 desc: "Predicted conversion probability",
+                 documentation: { example: 0.75 }
+      end
+      post "forecasts" do
+        {}
+      end
+    end
+
+    def test_oas2_emits_numeric_min_max_for_bigdecimal_range
+      schema = GrapeOAS.generate(app: SampleAPI, schema_type: :oas2)
+      property = schema.dig("definitions", "post_forecasts_Request", "properties", "conversion_probability")
+
+      refute_nil property
+      assert_equal "number", property["type"]
+      assert_equal "double", property["format"]
+      assert_kind_of Numeric, property["minimum"]
+      assert_kind_of Numeric, property["maximum"]
+      assert_in_delta 0.0, property["minimum"]
+      assert_in_delta 1.0, property["maximum"]
+
+      round_tripped = JSON.parse(JSON.generate(schema))
+      round_tripped_property = round_tripped.dig(
+        "definitions", "post_forecasts_Request", "properties", "conversion_probability",
+      )
+
+      # Regression: BigDecimal#to_json previously emitted strings like "0.1e1".
+      assert_kind_of Numeric, round_tripped_property["minimum"]
+      assert_kind_of Numeric, round_tripped_property["maximum"]
+    end
+
+    def test_oas3_emits_numeric_min_max_for_bigdecimal_range
+      schema = GrapeOAS.generate(app: SampleAPI, schema_type: :oas3)
+      property = schema.dig("components", "schemas", "post_forecasts_Request", "properties", "conversion_probability")
+
+      refute_nil property
+      assert_equal "number", property["type"]
+      assert_equal "double", property["format"]
+      assert_in_delta 0.75, property["example"]
+      assert_kind_of Numeric, property["minimum"]
+      assert_kind_of Numeric, property["maximum"]
+      assert_in_delta 0.0, property["minimum"]
+      assert_in_delta 1.0, property["maximum"]
+
+      round_tripped = JSON.parse(JSON.generate(schema))
+      round_tripped_property = round_tripped.dig(
+        "components", "schemas", "post_forecasts_Request", "properties", "conversion_probability",
+      )
+
+      assert_kind_of Numeric, round_tripped_property["minimum"]
+      assert_kind_of Numeric, round_tripped_property["maximum"]
+    end
+
+    def test_oas31_emits_numeric_min_max_for_bigdecimal_range
+      schema = GrapeOAS.generate(app: SampleAPI, schema_type: :oas31)
+      property = schema.dig("components", "schemas", "post_forecasts_Request", "properties", "conversion_probability")
+
+      refute_nil property
+      assert_equal "number", property["type"]
+      assert_kind_of Numeric, property["minimum"]
+      assert_kind_of Numeric, property["maximum"]
+
+      round_tripped = JSON.parse(JSON.generate(schema))
+      round_tripped_property = round_tripped.dig(
+        "components", "schemas", "post_forecasts_Request", "properties", "conversion_probability",
+      )
+
+      assert_kind_of Numeric, round_tripped_property["minimum"]
+      assert_kind_of Numeric, round_tripped_property["maximum"]
+    end
+  end
+end

--- a/test/e2e/generate_bigdecimal_param_test.rb
+++ b/test/e2e/generate_bigdecimal_param_test.rb
@@ -2,7 +2,6 @@
 
 require "test_helper"
 require "bigdecimal"
-require "bigdecimal/util"
 require "json"
 
 module GrapeOAS

--- a/test/grape_oas/api_model_builders/request_params_enum_test.rb
+++ b/test/grape_oas/api_model_builders/request_params_enum_test.rb
@@ -181,6 +181,47 @@ module GrapeOAS
         assert_in_delta(50.0, temp_param.schema.maximum)
       end
 
+      # === BigDecimal range values ===
+
+      def test_bigdecimal_range_values
+        require "bigdecimal"
+        require "bigdecimal/util"
+
+        api_class = Class.new(Grape::API) do
+          format :json
+          params do
+            optional :discount_rate,
+                     type: BigDecimal,
+                     values: BigDecimal(0)..BigDecimal(1),
+                     desc: "Discount rate applied to the order",
+                     documentation: { example: 0.25 }
+          end
+          get "orders" do
+            {}
+          end
+        end
+
+        route = api_class.routes.first
+        builder = RequestParams.new(api: @api, route: route)
+        _body_schema, params = builder.build
+
+        discount_param = params.find { |p| p.name == "discount_rate" }
+
+        refute_nil discount_param
+        refute discount_param.required
+        assert_equal "number", discount_param.schema.type
+        assert_equal "double", discount_param.schema.format
+        assert_equal "Discount rate applied to the order", discount_param.description
+        assert_in_delta 0.25, discount_param.schema.examples
+        # Bounds are coerced to Float so they serialize as JSON numbers, not
+        # strings (BigDecimal#to_json emits "0.1e1" etc.).
+        assert_in_delta 0.0, discount_param.schema.minimum
+        assert_in_delta 1.0, discount_param.schema.maximum
+        assert_kind_of Float, discount_param.schema.minimum
+        assert_kind_of Float, discount_param.schema.maximum
+        refute discount_param.schema.exclusive_maximum
+      end
+
       # === String range values ===
 
       def test_string_range_values

--- a/test/grape_oas/api_model_builders/request_params_enum_test.rb
+++ b/test/grape_oas/api_model_builders/request_params_enum_test.rb
@@ -185,7 +185,6 @@ module GrapeOAS
 
       def test_bigdecimal_range_values
         require "bigdecimal"
-        require "bigdecimal/util"
 
         api_class = Class.new(Grape::API) do
           format :json
@@ -213,8 +212,6 @@ module GrapeOAS
         assert_equal "double", discount_param.schema.format
         assert_equal "Discount rate applied to the order", discount_param.description
         assert_in_delta 0.25, discount_param.schema.examples
-        # Bounds are coerced to Float so they serialize as JSON numbers, not
-        # strings (BigDecimal#to_json emits "0.1e1" etc.).
         assert_in_delta 0.0, discount_param.schema.minimum
         assert_in_delta 1.0, discount_param.schema.maximum
         assert_kind_of Float, discount_param.schema.minimum

--- a/test/grape_oas/range_utils_test.rb
+++ b/test/grape_oas/range_utils_test.rb
@@ -263,5 +263,48 @@ module GrapeOAS
       assert_equal 100, constraint_set.maximum
       assert constraint_set.exclusive_maximum
     end
+
+    def test_apply_numeric_range_coerces_bigdecimal_bounds_to_float
+      require "bigdecimal"
+
+      schema = ApiModel::Schema.new(type: Constants::SchemaTypes::NUMBER)
+      RangeUtils.apply_numeric_range(schema, BigDecimal("0.5")..BigDecimal("2.5"))
+
+      # BigDecimal#to_json emits a string like "0.5e0", which would produce
+      # invalid OpenAPI output. Bounds must be coerced to Float.
+      assert_kind_of Float, schema.minimum
+      assert_kind_of Float, schema.maximum
+      assert_in_delta 0.5, schema.minimum
+      assert_in_delta 2.5, schema.maximum
+    end
+
+    def test_apply_numeric_range_leaves_integer_and_float_bounds_unchanged
+      schema = ApiModel::Schema.new(type: Constants::SchemaTypes::NUMBER)
+      RangeUtils.apply_numeric_range(schema, 1..10)
+
+      assert_kind_of Integer, schema.minimum
+      assert_kind_of Integer, schema.maximum
+
+      float_schema = ApiModel::Schema.new(type: Constants::SchemaTypes::NUMBER)
+      RangeUtils.apply_numeric_range(float_schema, 1.5..9.5)
+
+      assert_kind_of Float, float_schema.minimum
+      assert_kind_of Float, float_schema.maximum
+    end
+
+    def test_apply_numeric_range_bigdecimal_bounds_serialize_as_json_numbers
+      require "bigdecimal"
+      require "json"
+
+      schema = ApiModel::Schema.new(type: Constants::SchemaTypes::NUMBER)
+      RangeUtils.apply_numeric_range(schema, BigDecimal(0)..BigDecimal(1))
+
+      payload = JSON.parse({ minimum: schema.minimum, maximum: schema.maximum }.to_json)
+
+      assert_kind_of Numeric, payload["minimum"]
+      assert_kind_of Numeric, payload["maximum"]
+      assert_in_delta 0.0, payload["minimum"]
+      assert_in_delta 1.0, payload["maximum"]
+    end
   end
 end

--- a/test/grape_oas/range_utils_test.rb
+++ b/test/grape_oas/range_utils_test.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "bigdecimal"
+require "json"
 
 module GrapeOAS
   class RangeUtilsTest < Minitest::Test
@@ -265,13 +267,9 @@ module GrapeOAS
     end
 
     def test_apply_numeric_range_coerces_bigdecimal_bounds_to_float
-      require "bigdecimal"
-
       schema = ApiModel::Schema.new(type: Constants::SchemaTypes::NUMBER)
       RangeUtils.apply_numeric_range(schema, BigDecimal("0.5")..BigDecimal("2.5"))
 
-      # BigDecimal#to_json emits a string like "0.5e0", which would produce
-      # invalid OpenAPI output. Bounds must be coerced to Float.
       assert_kind_of Float, schema.minimum
       assert_kind_of Float, schema.maximum
       assert_in_delta 0.5, schema.minimum
@@ -293,9 +291,6 @@ module GrapeOAS
     end
 
     def test_apply_numeric_range_bigdecimal_bounds_serialize_as_json_numbers
-      require "bigdecimal"
-      require "json"
-
       schema = ApiModel::Schema.new(type: Constants::SchemaTypes::NUMBER)
       RangeUtils.apply_numeric_range(schema, BigDecimal(0)..BigDecimal(1))
 
@@ -305,6 +300,66 @@ module GrapeOAS
       assert_kind_of Numeric, payload["maximum"]
       assert_in_delta 0.0, payload["minimum"]
       assert_in_delta 1.0, payload["maximum"]
+    end
+
+    def test_apply_numeric_range_skips_bigdecimal_that_overflows_to_infinity
+      schema = ApiModel::Schema.new(type: Constants::SchemaTypes::NUMBER)
+
+      log_output = capture_grape_oas_log do
+        RangeUtils.apply_numeric_range(schema, BigDecimal("1e400")..BigDecimal("2e400"))
+      end
+
+      assert_nil schema.minimum
+      assert_nil schema.maximum
+      assert_nil schema.exclusive_maximum
+      assert_match(/overflows to Float::INFINITY/, log_output)
+    end
+
+    def test_apply_numeric_range_skips_only_overflowing_bound
+      schema = ApiModel::Schema.new(type: Constants::SchemaTypes::NUMBER)
+
+      log_output = capture_grape_oas_log do
+        RangeUtils.apply_numeric_range(schema, BigDecimal("1.0")..BigDecimal("1e400"))
+      end
+
+      assert_in_delta 1.0, schema.minimum
+      assert_nil schema.maximum
+      assert_nil schema.exclusive_maximum
+      assert_match(/overflows to Float::INFINITY/, log_output)
+    end
+
+    def test_apply_numeric_range_skips_overflowing_minimum_only
+      schema = ApiModel::Schema.new(type: Constants::SchemaTypes::NUMBER)
+
+      log_output = capture_grape_oas_log do
+        RangeUtils.apply_numeric_range(schema, BigDecimal("-1e400")..BigDecimal("5.0"))
+      end
+
+      assert_nil schema.minimum
+      assert_in_delta 5.0, schema.maximum
+      assert_match(/overflows to Float::INFINITY/, log_output)
+    end
+
+    def test_apply_numeric_range_coerces_exclusive_bigdecimal_range
+      schema = ApiModel::Schema.new(type: Constants::SchemaTypes::NUMBER)
+      RangeUtils.apply_numeric_range(schema, BigDecimal("0.5")...BigDecimal("2.5"))
+
+      assert_kind_of Float, schema.minimum
+      assert_kind_of Float, schema.maximum
+      assert_in_delta 0.5, schema.minimum
+      assert_in_delta 2.5, schema.maximum
+      assert schema.exclusive_maximum
+    end
+
+    def test_apply_numeric_range_logs_precision_loss
+      schema = ApiModel::Schema.new(type: Constants::SchemaTypes::NUMBER)
+
+      log_output = capture_grape_oas_log(level: Logger::DEBUG) do
+        RangeUtils.apply_numeric_range(schema, BigDecimal("9007199254740993")..BigDecimal("9007199254740993"))
+      end
+
+      assert_kind_of Float, schema.minimum
+      assert_match(/lost precision/, log_output)
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -47,10 +47,10 @@ require "logger"
 require "stringio"
 
 module LoggerCaptureHelper
-  def capture_grape_oas_log
+  def capture_grape_oas_log(level: Logger::WARN)
     log_output = StringIO.new
     original_logger = GrapeOAS.logger
-    captured_logger = Logger.new(log_output, progname: "grape-oas", level: Logger::WARN)
+    captured_logger = Logger.new(log_output, progname: "grape-oas", level: level)
     captured_logger.formatter = GrapeOAS::LOG_FORMATTER
     GrapeOAS.logger = captured_logger
     begin


### PR DESCRIPTION
## Summary

- `BigDecimal#to_json` emits scientific-notation strings (e.g. `"0.1e1"`), so a `values: BigDecimal(0)..BigDecimal(1)` constraint on a param produced invalid OpenAPI output where `minimum`/`maximum` were JSON strings instead of numbers.
- Fix: `RangeUtils.apply_numeric_range` now coerces `BigDecimal` bounds to `Float` before assigning them, so they render as JSON number literals. Other numeric types pass through unchanged. Guarded with `defined?(BigDecimal)` to keep `optional_bigdecimal_dependency_test.rb` green when bigdecimal isn't loaded.
- Coverage: unit tests in `range_utils_test.rb` (coercion behavior + JSON round-trip), a new test in `request_params_enum_test.rb` (parameter-level schema), and a new e2e file `generate_bigdecimal_param_test.rb` that generates the full spec for OAS2, OAS3, and OAS3.1 and round-trips through `JSON.generate`/`JSON.parse` to lock in the regression guard.

## Before / after

Previously for `values: BigDecimal(0)..BigDecimal(1)`:
```json
{ "minimum": "0.0", "maximum": "0.1e1" }
```

Now:
```json
{ "minimum": 0.0, "maximum": 1.0 }
```

## Test plan

- [x] `bundle exec ruby -Itest test/grape_oas/range_utils_test.rb`
- [x] `bundle exec ruby -Itest test/grape_oas/api_model_builders/request_params_enum_test.rb`
- [x] `bundle exec ruby -Itest test/e2e/generate_bigdecimal_param_test.rb`
- [x] Full suite via `rake test` (one pre-existing unrelated failure in `optional_bigdecimal_dependency_test` — bundler output leaks into subprocess; same failure on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)