### PR TITLE
Emit OAS-version-correct schema for file types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#61](https://github.com/numbata/grape-oas/pull/61): Respect `entity_name` on `grape::entity` subclasses - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#68](https://github.com/numbata/grape-oas/pull/68): De-duplicate parameter `description` between the Parameter Object and its nested `schema` in OAS 3 output - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#70](https://github.com/numbata/grape-oas/pull/70): Propagate schema attributes (`default`, `enum`, constraints, extensions) through `$ref` and composition paths - [@numbata](https://github.com/numbata).
+- [#76](https://github.com/numbata/grape-oas/pull/76): Emit oas-version-correct schema for file types - [@olivier-thatch](https://github.com/olivier-thatch).
+- Your contribution here
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#78](https://github.com/numbata/grape-oas/pull/78): Fix: use empty schema for undocumented responses instead of `{ type: string }` - [@bogdan](https://github.com/bogdan).
 - [#74](https://github.com/numbata/grape-oas/pull/74): Fix BigDecimal range bounds serializing as JSON strings - [@olivier-thatch](https://github.com/olivier-thatch).
+- [#76](https://github.com/numbata/grape-oas/pull/76): Emit OAS-version-correct schema for file types - [@olivier-thatch](https://github.com/olivier-thatch).
 * Your contribution here
 
 ### Changed
@@ -28,8 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#61](https://github.com/numbata/grape-oas/pull/61): Respect `entity_name` on `grape::entity` subclasses - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#68](https://github.com/numbata/grape-oas/pull/68): De-duplicate parameter `description` between the Parameter Object and its nested `schema` in OAS 3 output - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#70](https://github.com/numbata/grape-oas/pull/70): Propagate schema attributes (`default`, `enum`, constraints, extensions) through `$ref` and composition paths - [@numbata](https://github.com/numbata).
-- [#76](https://github.com/numbata/grape-oas/pull/76): Emit oas-version-correct schema for file types - [@olivier-thatch](https://github.com/olivier-thatch).
-- Your contribution here
 
 ### Changed
 

--- a/lib/grape_oas/exporter/oas2/schema.rb
+++ b/lib/grape_oas/exporter/oas2/schema.rb
@@ -10,6 +10,8 @@ module GrapeOAS
           @nullable_strategy = nullable_strategy
         end
 
+        # OAS 2.0 (Swagger) natively supports `type: file`, so no
+        # file-type normalization is needed here (unlike OAS 3.x).
         def build
           return {} unless @schema
 
@@ -151,7 +153,9 @@ module GrapeOAS
               result
             end
           else
-            built = Schema.new(schema, @ref_tracker, nullable_strategy: @nullable_strategy).build
+            # self.class preserves any subclass so nested schemas use
+            # the version-correct builder.
+            built = self.class.new(schema, @ref_tracker, nullable_strategy: @nullable_strategy).build
             built.delete("description") unless include_metadata
             built
           end

--- a/lib/grape_oas/exporter/oas3/schema.rb
+++ b/lib/grape_oas/exporter/oas3/schema.rb
@@ -21,7 +21,17 @@ module GrapeOAS
           sanitize_enum_against_type(schema_hash)
           apply_extensions_and_extra_properties(schema_hash)
           apply_all_constraints(schema_hash)
+          normalize_file_type!(schema_hash)
           schema_hash.compact
+        end
+
+        # OAS3.0 does not support `type: file`. Files are represented as
+        # `type: string, format: binary`. OAS3.1 subclasses override this.
+        def normalize_file_type!(hash)
+          return unless hash["type"] == Constants::SchemaTypes::FILE
+
+          hash["type"] = Constants::SchemaTypes::STRING
+          hash["format"] = "binary"
         end
 
         def build_base_hash
@@ -190,7 +200,7 @@ module GrapeOAS
               result
             end
           else
-            built = Schema.new(schema, @ref_tracker, nullable_strategy: @nullable_strategy).build
+            built = self.class.new(schema, @ref_tracker, nullable_strategy: @nullable_strategy).build
             strip_items_metadata(built) unless include_metadata
             built
           end

--- a/lib/grape_oas/exporter/oas3/schema.rb
+++ b/lib/grape_oas/exporter/oas3/schema.rb
@@ -25,15 +25,6 @@ module GrapeOAS
           schema_hash.compact
         end
 
-        # OAS3.0 does not support `type: file`. Files are represented as
-        # `type: string, format: binary`. OAS3.1 subclasses override this.
-        def normalize_file_type!(hash)
-          return unless hash["type"] == Constants::SchemaTypes::FILE
-
-          hash["type"] = Constants::SchemaTypes::STRING
-          hash["format"] = "binary"
-        end
-
         def build_base_hash
           schema_hash = {}
           schema_hash["type"] = nullable_type
@@ -91,6 +82,26 @@ module GrapeOAS
 
         private
 
+        # Rewrites `type: file` (or `type: ["file", "null"]`) to the
+        # version-appropriate representation. Type detection lives here;
+        # version-specific attributes are set by `apply_file_schema_attributes!`.
+        def normalize_file_type!(hash)
+          type = hash["type"]
+          if type == Constants::SchemaTypes::FILE
+            hash["type"] = Constants::SchemaTypes::STRING
+            apply_file_schema_attributes!(hash)
+          elsif type.is_a?(Array) && type.include?(Constants::SchemaTypes::FILE)
+            hash["type"] = type.map { |t| t == Constants::SchemaTypes::FILE ? Constants::SchemaTypes::STRING : t }
+            apply_file_schema_attributes!(hash)
+          end
+        end
+
+        # OAS 3.0: files are `type: string, format: binary`.
+        # OAS 3.1 overrides this with content-* keywords.
+        def apply_file_schema_attributes!(hash)
+          hash["format"] = "binary"
+        end
+
         # Build allOf schema for inheritance
         def build_all_of_schema
           items = @schema.all_of.map { |item| build_schema_or_ref(item) }
@@ -129,6 +140,8 @@ module GrapeOAS
           sanitize_enum_against_type(result)
           apply_all_constraints(result)
           result.merge!(@schema.extensions) if @schema.extensions
+          normalize_file_type!(result)
+          result
         end
 
         # Build OAS3 discriminator object
@@ -200,6 +213,8 @@ module GrapeOAS
               result
             end
           else
+            # self.class preserves the OAS version subclass (e.g. OAS31::Schema)
+            # so nested schemas get version-correct normalization.
             built = self.class.new(schema, @ref_tracker, nullable_strategy: @nullable_strategy).build
             strip_items_metadata(built) unless include_metadata
             built

--- a/lib/grape_oas/exporter/oas31/schema.rb
+++ b/lib/grape_oas/exporter/oas31/schema.rb
@@ -22,6 +22,16 @@ module GrapeOAS
           hash
         end
 
+        # OAS3.1 represents files using JSON Schema's content-* keywords
+        # rather than the OAS3.0 `format: binary` convention.
+        def normalize_file_type!(hash)
+          return unless hash["type"] == Constants::SchemaTypes::FILE
+
+          hash["type"] = Constants::SchemaTypes::STRING
+          hash["contentMediaType"] = "application/octet-stream"
+          hash["contentEncoding"] = "binary"
+        end
+
         private
 
         # Ensure examples is always an array and recurse into nested schemas

--- a/lib/grape_oas/exporter/oas31/schema.rb
+++ b/lib/grape_oas/exporter/oas31/schema.rb
@@ -22,17 +22,15 @@ module GrapeOAS
           hash
         end
 
-        # OAS3.1 represents files using JSON Schema's content-* keywords
-        # rather than the OAS3.0 `format: binary` convention.
-        def normalize_file_type!(hash)
-          return unless hash["type"] == Constants::SchemaTypes::FILE
+        private
 
-          hash["type"] = Constants::SchemaTypes::STRING
+        # OAS 3.1: files use JSON Schema content-* keywords instead of
+        # the OAS 3.0 `format: binary` convention.
+        def apply_file_schema_attributes!(hash)
+          hash.delete("format")
           hash["contentMediaType"] = "application/octet-stream"
           hash["contentEncoding"] = "binary"
         end
-
-        private
 
         # Ensure examples is always an array and recurse into nested schemas
         def normalize_examples!(hash)

--- a/test/e2e/generate_array_of_files_test.rb
+++ b/test/e2e/generate_array_of_files_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GrapeOAS
+  # Tests how grape-oas serializes an array-of-files parameter
+  # (`type: [File]`) across OAS 2.0, 3.0, and 3.1.
+  class GenerateArrayOfFilesTest < Minitest::Test
+    class SampleAPI < Grape::API
+      format :json
+
+      desc "Bulk upload"
+      params do
+        requires :files, type: [File]
+      end
+      post "bulk_upload" do
+        {}
+      end
+    end
+
+    def test_oas2_array_of_files_property
+      schema = GrapeOAS.generate(app: SampleAPI, schema_type: :oas2)
+      body = schema.dig("paths", "/bulk_upload", "post", "parameters").find { |p| p["in"] == "body" }
+      ref = body.dig("schema", "$ref")
+      files = schema.dig(*ref.delete_prefix("#/").split("/"), "properties", "files")
+
+      assert_equal "array", files["type"]
+      assert_equal({ "type" => "file" }, files["items"])
+    end
+
+    def test_oas3_array_of_files_property
+      schema = GrapeOAS.generate(app: SampleAPI, schema_type: :oas3)
+      ref = schema.dig("paths", "/bulk_upload", "post", "requestBody", "content", "application/json", "schema", "$ref")
+      files = schema.dig(*ref.delete_prefix("#/").split("/"), "properties", "files")
+
+      assert_equal "array", files["type"]
+      assert_equal({ "type" => "string", "format" => "binary" }, files["items"])
+    end
+
+    def test_oas3_route_uses_request_body
+      schema = GrapeOAS.generate(app: SampleAPI, schema_type: :oas3)
+      op = schema.dig("paths", "/bulk_upload", "post")
+
+      assert op["requestBody"], "/bulk_upload should have a requestBody"
+      assert_nil op["parameters"], "/bulk_upload should not emit query/path parameters"
+    end
+
+    def test_oas31_array_of_files_property
+      schema = GrapeOAS.generate(app: SampleAPI, schema_type: :oas31)
+      ref = schema.dig("paths", "/bulk_upload", "post", "requestBody", "content", "application/json", "schema", "$ref")
+      files = schema.dig(*ref.delete_prefix("#/").split("/"), "properties", "files")
+
+      assert_equal "array", files["type"]
+      assert_equal(
+        {
+          "type" => "string",
+          "contentMediaType" => "application/octet-stream",
+          "contentEncoding" => "binary"
+        },
+        files["items"],
+      )
+    end
+  end
+end

--- a/test/e2e/generate_array_of_files_test.rb
+++ b/test/e2e/generate_array_of_files_test.rb
@@ -3,8 +3,7 @@
 require "test_helper"
 
 module GrapeOAS
-  # Tests how grape-oas serializes an array-of-files parameter
-  # (`type: [File]`) across OAS 2.0, 3.0, and 3.1.
+  # Tests file-type parameter serialization across OAS 2.0, 3.0, and 3.1.
   class GenerateArrayOfFilesTest < Minitest::Test
     class SampleAPI < Grape::API
       format :json
@@ -14,6 +13,14 @@ module GrapeOAS
         requires :files, type: [File]
       end
       post "bulk_upload" do
+        {}
+      end
+
+      desc "Single upload"
+      params do
+        requires :file, type: File
+      end
+      post "upload" do
         {}
       end
     end
@@ -59,6 +66,37 @@ module GrapeOAS
         },
         files["items"],
       )
+    end
+
+    # === Standalone file parameter ===
+
+    def test_oas2_standalone_file_property
+      schema = GrapeOAS.generate(app: SampleAPI, schema_type: :oas2)
+      body = schema.dig("paths", "/upload", "post", "parameters").find { |p| p["in"] == "body" }
+      ref = body.dig("schema", "$ref")
+      file = schema.dig(*ref.delete_prefix("#/").split("/"), "properties", "file")
+
+      assert_equal "file", file["type"]
+    end
+
+    def test_oas3_standalone_file_property
+      schema = GrapeOAS.generate(app: SampleAPI, schema_type: :oas3)
+      ref = schema.dig("paths", "/upload", "post", "requestBody", "content", "application/json", "schema", "$ref")
+      file = schema.dig(*ref.delete_prefix("#/").split("/"), "properties", "file")
+
+      assert_equal "string", file["type"]
+      assert_equal "binary", file["format"]
+    end
+
+    def test_oas31_standalone_file_property
+      schema = GrapeOAS.generate(app: SampleAPI, schema_type: :oas31)
+      ref = schema.dig("paths", "/upload", "post", "requestBody", "content", "application/json", "schema", "$ref")
+      file = schema.dig(*ref.delete_prefix("#/").split("/"), "properties", "file")
+
+      assert_equal "string", file["type"]
+      assert_equal "application/octet-stream", file["contentMediaType"]
+      assert_equal "binary", file["contentEncoding"]
+      refute file.key?("format")
     end
   end
 end

--- a/test/grape_oas/exporter/oas31_schema_test.rb
+++ b/test/grape_oas/exporter/oas31_schema_test.rb
@@ -66,6 +66,55 @@ module GrapeOAS
         assert_equal 2, offset["maximum"]
       end
 
+      # === File type normalization (OAS 3.1) ===
+      # OAS 3.1 uses JSON Schema content-* keywords instead of the
+      # OAS 3.0 `format: binary` convention.
+
+      def test_file_type_becomes_string_with_content_keywords
+        schema = ApiModel::Schema.new(type: "file")
+
+        result = OAS31::Schema.new(schema).build
+
+        assert_equal "string", result["type"]
+        assert_equal "application/octet-stream", result["contentMediaType"]
+        assert_equal "binary", result["contentEncoding"]
+        refute result.key?("format"), "OAS 3.1 should not emit 'format: binary'"
+      end
+
+      def test_array_of_files_items_get_content_keywords
+        items = ApiModel::Schema.new(type: "file")
+        array = ApiModel::Schema.new(type: "array", items: items)
+
+        result = OAS31::Schema.new(array).build
+
+        assert_equal "array", result["type"]
+        assert_equal(
+          {
+            "type" => "string",
+            "contentMediaType" => "application/octet-stream",
+            "contentEncoding" => "binary"
+          },
+          result["items"],
+        )
+      end
+
+      def test_file_typed_property_gets_content_keywords
+        file_prop = ApiModel::Schema.new(type: "file")
+        object = ApiModel::Schema.new(type: "object")
+        object.add_property("avatar", file_prop)
+
+        result = OAS31::Schema.new(object).build
+
+        assert_equal(
+          {
+            "type" => "string",
+            "contentMediaType" => "application/octet-stream",
+            "contentEncoding" => "binary"
+          },
+          result["properties"]["avatar"],
+        )
+      end
+
       private
 
       def generate_doc_with_schema(schema)

--- a/test/grape_oas/exporter/oas31_schema_test.rb
+++ b/test/grape_oas/exporter/oas31_schema_test.rb
@@ -115,6 +115,86 @@ module GrapeOAS
         )
       end
 
+      def test_nullable_file_type_becomes_nullable_string_with_content_keywords
+        schema = ApiModel::Schema.new(type: "file", nullable: true)
+
+        result = OAS31::Schema.new(
+          schema, nil,
+          nullable_strategy: Constants::NullableStrategy::TYPE_ARRAY,
+        ).build
+
+        assert_equal %w[string null], result["type"]
+        assert_equal "application/octet-stream", result["contentMediaType"]
+        assert_equal "binary", result["contentEncoding"]
+        refute result.key?("format")
+      end
+
+      def test_allof_with_file_type_normalizes_to_content_keywords
+        child = ApiModel::Schema.new(type: "object")
+        schema = ApiModel::Schema.new(all_of: [child], type: "file")
+
+        result = OAS31::Schema.new(schema).build
+
+        assert result.key?("allOf")
+        assert_equal "string", result["type"]
+        assert_equal "application/octet-stream", result["contentMediaType"]
+        assert_equal "binary", result["contentEncoding"]
+        refute result.key?("format")
+      end
+
+      def test_allof_with_file_type_and_explicit_format_drops_format
+        child = ApiModel::Schema.new(type: "object")
+        schema = ApiModel::Schema.new(all_of: [child], type: "file")
+        schema.format = "binary"
+
+        result = OAS31::Schema.new(schema).build
+
+        assert result.key?("allOf")
+        assert_equal "string", result["type"]
+        assert_equal "application/octet-stream", result["contentMediaType"]
+        assert_equal "binary", result["contentEncoding"]
+        refute result.key?("format"), "OAS 3.1 file normalization should remove format even when explicitly set"
+      end
+
+      def test_file_type_with_explicit_format_drops_format
+        schema = ApiModel::Schema.new(type: "file")
+        schema.format = "binary"
+
+        result = OAS31::Schema.new(schema).build
+
+        assert_equal "string", result["type"]
+        assert_equal "application/octet-stream", result["contentMediaType"]
+        assert_equal "binary", result["contentEncoding"]
+        refute result.key?("format"), "OAS 3.1 file normalization should remove format"
+      end
+
+      def test_oneof_with_file_type_normalizes_to_content_keywords
+        variant = ApiModel::Schema.new(type: "object")
+        schema = ApiModel::Schema.new(one_of: [variant], type: "file")
+
+        result = OAS31::Schema.new(schema).build
+
+        assert result.key?("oneOf")
+        assert_equal "string", result["type"]
+        assert_equal "application/octet-stream", result["contentMediaType"]
+        assert_equal "binary", result["contentEncoding"]
+      end
+
+      def test_anyof_with_nullable_file_type_normalizes
+        variant = ApiModel::Schema.new(type: "object")
+        schema = ApiModel::Schema.new(any_of: [variant], type: "file", nullable: true)
+
+        result = OAS31::Schema.new(
+          schema, nil,
+          nullable_strategy: Constants::NullableStrategy::TYPE_ARRAY,
+        ).build
+
+        assert result.key?("anyOf")
+        assert_equal %w[string null], result["type"]
+        assert_equal "application/octet-stream", result["contentMediaType"]
+        assert_equal "binary", result["contentEncoding"]
+      end
+
       private
 
       def generate_doc_with_schema(schema)

--- a/test/grape_oas/exporter/oas3_schema_test.rb
+++ b/test/grape_oas/exporter/oas3_schema_test.rb
@@ -892,6 +892,39 @@ module GrapeOAS
         assert result["items"]["x-nullable"], "x-nullable should be on the composed items schema"
         assert result["items"]["oneOf"], "oneOf should be present on items"
       end
+
+      # === File type normalization (OAS 3.0) ===
+      # OAS 3.0 does not support `type: file`; files are represented as
+      # `type: string, format: binary`.
+
+      def test_file_type_becomes_string_with_binary_format
+        schema = ApiModel::Schema.new(type: "file")
+
+        result = OAS3::Schema.new(schema).build
+
+        assert_equal "string", result["type"]
+        assert_equal "binary", result["format"]
+      end
+
+      def test_array_of_files_items_become_string_with_binary_format
+        items = ApiModel::Schema.new(type: "file")
+        array = ApiModel::Schema.new(type: "array", items: items)
+
+        result = OAS3::Schema.new(array).build
+
+        assert_equal "array", result["type"]
+        assert_equal({ "type" => "string", "format" => "binary" }, result["items"])
+      end
+
+      def test_file_typed_property_becomes_string_with_binary_format
+        file_prop = ApiModel::Schema.new(type: "file")
+        object = ApiModel::Schema.new(type: "object")
+        object.add_property("avatar", file_prop)
+
+        result = OAS3::Schema.new(object).build
+
+        assert_equal({ "type" => "string", "format" => "binary" }, result["properties"]["avatar"])
+      end
     end
   end
 end

--- a/test/grape_oas/exporter/oas3_schema_test.rb
+++ b/test/grape_oas/exporter/oas3_schema_test.rb
@@ -925,6 +925,58 @@ module GrapeOAS
 
         assert_equal({ "type" => "string", "format" => "binary" }, result["properties"]["avatar"])
       end
+
+      def test_nullable_file_type_array_strategy_becomes_nullable_string_with_binary_format
+        schema = ApiModel::Schema.new(type: "file", nullable: true)
+
+        result = OAS3::Schema.new(schema, nil, nullable_strategy: Constants::NullableStrategy::TYPE_ARRAY).build
+
+        assert_equal %w[string null], result["type"]
+        assert_equal "binary", result["format"]
+      end
+
+      def test_nullable_file_keyword_strategy_becomes_string_with_binary_format_and_nullable
+        schema = ApiModel::Schema.new(type: "file", nullable: true)
+
+        result = OAS3::Schema.new(schema, nil, nullable_strategy: Constants::NullableStrategy::KEYWORD).build
+
+        assert_equal "string", result["type"]
+        assert_equal "binary", result["format"]
+        assert result["nullable"]
+      end
+
+      def test_allof_with_file_type_normalizes
+        child = ApiModel::Schema.new(type: "object")
+        schema = ApiModel::Schema.new(all_of: [child], type: "file")
+
+        result = OAS3::Schema.new(schema).build
+
+        assert result.key?("allOf")
+        assert_equal "string", result["type"]
+        assert_equal "binary", result["format"]
+      end
+
+      def test_oneof_with_file_type_normalizes
+        variant = ApiModel::Schema.new(type: "object")
+        schema = ApiModel::Schema.new(one_of: [variant], type: "file")
+
+        result = OAS3::Schema.new(schema).build
+
+        assert result.key?("oneOf")
+        assert_equal "string", result["type"]
+        assert_equal "binary", result["format"]
+      end
+
+      def test_anyof_with_file_type_normalizes
+        variant = ApiModel::Schema.new(type: "object")
+        schema = ApiModel::Schema.new(any_of: [variant], type: "file")
+
+        result = OAS3::Schema.new(schema).build
+
+        assert result.key?("anyOf")
+        assert_equal "string", result["type"]
+        assert_equal "binary", result["format"]
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

- `type: file` is only valid in OAS 2.0. In OAS 3.0 it must be `type: string, format: binary`; in OAS 3.1 it must use `type: string, contentMediaType: application/octet-stream, contentEncoding: binary`. grape-oas previously emitted the OAS 2.0 form across all three, producing invalid 3.x schemas for `File` and `Array[File]` params.
- `OAS3::Schema` now normalizes `type: file` at render time to the 3.0 form; `OAS31::Schema` overrides the hook for the 3.1 form.
- `build_schema_or_ref` in `OAS3::Schema` now uses `self.class.new` instead of the hard-coded `Schema.new`, so the OAS31 override reaches nested `items` and object properties — without this, only the outermost schema would be normalized for OAS 3.1.
- OAS 2.0 output is unchanged.

## Output

| Version | `type: Array[File]` emits |
|---|---|
| OAS 2.0 | `{ type: "array", items: { type: "file" } }` |
| OAS 3.0 | `{ type: "array", items: { type: "string", format: "binary" } }` |
| OAS 3.1 | `{ type: "array", items: { type: "string", contentMediaType: "application/octet-stream", contentEncoding: "binary" } }` |

## Test plan

- [x] New e2e test `test/e2e/generate_array_of_files_test.rb` covers `Array[File]` across OAS 2.0, 3.0, and 3.1.
- [x] New unit tests in `oas3_schema_test.rb` and `oas31_schema_test.rb` exercise top-level, array-items, and object-property file normalization.
- [x] `request_params_file_upload_test.rb` still passes (internal `ApiModel::Schema` still uses `type: "file"`; only the exporter rewrites it).
- [x] Full suite green aside from one pre-existing, unrelated failure in `optional_bigdecimal_dependency_test.rb` caused by bundler's "Resolving dependencies…" stdout leaking into an IO-capture assertion — reproduces on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)