### PR TITLE
Fix: use empty schema for undocumented responses instead of { type: string }

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#78](https://github.com/numbata/grape-oas/pull/78): Fix: use empty schema for undocumented responses instead of `{ type: string }` - [@bogdan](https://github.com/bogdan).
 * Your contribution here
 
 ### Changed
@@ -26,7 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#61](https://github.com/numbata/grape-oas/pull/61): Respect `entity_name` on `grape::entity` subclasses - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#68](https://github.com/numbata/grape-oas/pull/68): De-duplicate parameter `description` between the Parameter Object and its nested `schema` in OAS 3 output - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#70](https://github.com/numbata/grape-oas/pull/70): Propagate schema attributes (`default`, `enum`, constraints, extensions) through `$ref` and composition paths - [@numbata](https://github.com/numbata).
-- [#78](https://github.com/numbata/grape-oas/pull/78): Fix: use empty schema for undocumented responses instead of `{ type: string }` - [@bogdan](https://github.com/bogdan).
 - Your contribution here
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#59](https://github.com/numbata/grape-oas/pull/59): Export `default` param values to OAS2 and OAS3 output - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#61](https://github.com/numbata/grape-oas/pull/61): Respect `entity_name` on `grape::entity` subclasses - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#68](https://github.com/numbata/grape-oas/pull/68): De-duplicate parameter `description` between the Parameter Object and its nested `schema` in OAS 3 output - [@olivier-thatch](https://github.com/olivier-thatch).
+- [#78](https://github.com/numbata/grape-oas/pull/78): Fix: use empty schema for undocumented responses instead of `{ type: string }` - [@bogdan](https://github.com/bogdan).
 - Your contribution here
 
 ### Changed

--- a/lib/grape_oas/api_model_builders/response.rb
+++ b/lib/grape_oas/api_model_builders/response.rb
@@ -238,7 +238,7 @@ module GrapeOAS
       # Build schema for response body
       # Delegates to EntityIntrospector when entity is present
       def build_schema(entity_class)
-        return GrapeOAS::ApiModel::Schema.new(type: Constants::SchemaTypes::STRING) unless entity_class
+        return GrapeOAS::ApiModel::Schema.new unless entity_class
 
         GrapeOAS.introspectors.build_schema(entity_class, stack: [], registry: {})
       end

--- a/test/grape_oas/api_model_builders/response_test.rb
+++ b/test/grape_oas/api_model_builders/response_test.rb
@@ -44,7 +44,7 @@ module GrapeOAS
         assert_equal "application/json", media_type.mime_type
       end
 
-      def test_builds_string_schema_when_no_entity
+      def test_builds_empty_schema_when_no_entity
         api_class = Class.new(Grape::API) do
           format :json
           get "users" do

--- a/test/grape_oas/api_model_builders/response_test.rb
+++ b/test/grape_oas/api_model_builders/response_test.rb
@@ -58,7 +58,7 @@ module GrapeOAS
 
         schema = response.media_types.first.schema
 
-        assert_equal "string", schema.type
+        assert_nil schema.type
       end
 
       def test_builds_object_schema_with_entity

--- a/test/grape_oas/exporter/oas2_response_test.rb
+++ b/test/grape_oas/exporter/oas2_response_test.rb
@@ -5,6 +5,16 @@ require "test_helper"
 module GrapeOAS
   module Exporter
     class OAS2ResponseTest < Minitest::Test
+      def test_emits_empty_schema_when_no_entity
+        schema = ApiModel::Schema.new
+        media = ApiModel::MediaType.new(mime_type: "application/json", schema: schema)
+        resp = ApiModel::Response.new(http_status: "200", description: "Success", media_types: [media])
+
+        result = Exporter::OAS2::Response.new([resp]).build
+
+        assert_equal({}, result["200"]["schema"])
+      end
+
       def test_includes_headers_and_examples
         schema = ApiModel::Schema.new(type: "string")
         media = ApiModel::MediaType.new(mime_type: "application/json", schema: schema,

--- a/test/grape_oas/exporter/oas3_response_test.rb
+++ b/test/grape_oas/exporter/oas3_response_test.rb
@@ -5,6 +5,16 @@ require "test_helper"
 module GrapeOAS
   module Exporter
     class OAS3ResponseTest < Minitest::Test
+      def test_emits_empty_schema_when_no_entity
+        schema = ApiModel::Schema.new
+        media = ApiModel::MediaType.new(mime_type: "application/json", schema: schema)
+        resp = ApiModel::Response.new(http_status: "200", description: "Success", media_types: [media])
+
+        result = Exporter::OAS3::Response.new([resp]).build
+
+        assert_equal({}, result["200"]["content"]["application/json"]["schema"])
+      end
+
       def test_headers_have_schema_wrapper
         schema = ApiModel::Schema.new(type: "string")
         media = ApiModel::MediaType.new(mime_type: "application/json", schema: schema)


### PR DESCRIPTION
## Problem

When a route has no entity, grape-oas emits `schema: { type: string }` for the response body. This is incorrect — it tells API consumers the endpoint returns a plain string, when in reality the response shape is simply unknown.

## Fix

An undocumented response should produce an empty schema (`{}`), which is the correct OAS representation for "any value / shape unknown".

## Test change

Updated an existing test that was asserting the buggy behavior rather than the intended one.