### PR TITLE
Fix docs: nickname is supported in grape-oas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#59](https://github.com/numbata/grape-oas/pull/59): Export `default` param values to OAS2 and OAS3 output - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#61](https://github.com/numbata/grape-oas/pull/61): Respect `entity_name` on `grape::entity` subclasses - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#68](https://github.com/numbata/grape-oas/pull/68): De-duplicate parameter `description` between the Parameter Object and its nested `schema` in OAS 3 output - [@olivier-thatch](https://github.com/olivier-thatch).
+- [#79](https://github.com/numbata/grape-oas/pull/79): Fix docs: `nickname` is supported in grape-oas - [@bogdan](https://github.com/bogdan).
 - Your contribution here
 
 ### Changed

--- a/docs/MIGRATING_FROM_GRAPE_SWAGGER.md
+++ b/docs/MIGRATING_FROM_GRAPE_SWAGGER.md
@@ -674,8 +674,6 @@ These grape-swagger features are not currently available in grape-oas:
 4. **Nested Namespace as Standalone** (`swagger: { nested: false }`)
    - All namespaces follow standard Grape routing
 
-
-
 ---
 
 ## New Features in grape-oas

--- a/docs/MIGRATING_FROM_GRAPE_SWAGGER.md
+++ b/docs/MIGRATING_FROM_GRAPE_SWAGGER.md
@@ -192,7 +192,7 @@ end
 |--------|---------------|-----------|-------|
 | `hidden` | ✅ | ✅ | Hide endpoint from docs |
 | `hidden` (lambda) | ✅ | ✅ | Conditional hiding |
-| `nickname` | ✅ | ❌ | Use auto-generated operationId |
+| `nickname` | ✅ | ✅ | Used as operationId |
 | `detail` | ✅ | ✅ | Extended description |
 | `summary` | ✅ | ✅ | Override summary |
 | `tags` | ✅ | ✅ | Override tags |
@@ -652,7 +652,7 @@ get ':id' do; end
 | Multiple present (`as:`) | ✅ | ✅ | Fully supported |
 | Root wrapping | ✅ | ❌ | Not implemented |
 | Nested namespace standalone | ✅ | ❌ | Not implemented |
-| Custom operationId (nickname) | ✅ | ❌ | Auto-generated only |
+| Custom operationId (nickname) | ✅ | ✅ | Used as operationId |
 | body_name override | ✅ | ✅ | OAS 2.0 only |
 
 ---
@@ -674,8 +674,6 @@ These grape-swagger features are not currently available in grape-oas:
 4. **Nested Namespace as Standalone** (`swagger: { nested: false }`)
    - All namespaces follow standard Grape routing
 
-5. **Custom operationId** (`nickname:`)
-   - operationId is auto-generated from method and path
 
 
 ---
@@ -793,7 +791,6 @@ See [EXPORTERS.md](EXPORTERS.md) for details.
 - [ ] Update OAuth2 security definitions format if targeting OAS 3.x
 - [ ] Remove any `endpoint_auth_wrapper`/`swagger_endpoint_guard`/`token_owner` options
 - [ ] Test generated output against your existing schema
-- [ ] Update any code that depends on `nickname` (operationId is now auto-generated)
 - [ ] Migrate custom model parsers to introspector registry (see [INTROSPECTORS.md](INTROSPECTORS.md))
 - [ ] Review any root element wrapping (not supported - create wrapper entity)
 


### PR DESCRIPTION
## Problem

The migration guide incorrectly listed `nickname` as unsupported, telling users to expect auto-generated operationIds and to update any code relying on it. The feature has always worked — tests confirm it.

## Fix

Updated the options table, feature comparison table, and "Features Not Yet Supported" section to reflect that `nickname` is respected as operationId.