### PR TITLE
Fix: hide documentation routes from generated spec by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#78](https://github.com/numbata/grape-oas/pull/78): Fix: use empty schema for undocumented responses instead of `{ type: string }` - [@bogdan](https://github.com/bogdan).
 - [#74](https://github.com/numbata/grape-oas/pull/74): Fix BigDecimal range bounds serializing as JSON strings - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#76](https://github.com/numbata/grape-oas/pull/76): Emit OAS-version-correct schema for file types - [@olivier-thatch](https://github.com/olivier-thatch).
+- [#80](https://github.com/numbata/grape-oas/pull/80): Fix: hide documentation routes from generated spec by default - [@bogdan](https://github.com/bogdan).
 * Your contribution here
 
 ### Changed

--- a/lib/grape_oas/documentation_extension.rb
+++ b/lib/grape_oas/documentation_extension.rb
@@ -79,10 +79,9 @@ module GrapeOAS
       return super if defined?(::GrapeSwagger)
 
       options = options.dup
-      hide_doc = options.delete(:hide_documentation_path) { true }
       options[:oas_doc_version] ||= :oas2
       options[:oas_mount_path] ||= options[:mount_path] || "/swagger_doc.json"
-      add_oas_documentation(hide_documentation_path: hide_doc, **options)
+      add_oas_documentation(**options)
     end
 
     private

--- a/lib/grape_oas/documentation_extension.rb
+++ b/lib/grape_oas/documentation_extension.rb
@@ -79,9 +79,10 @@ module GrapeOAS
       return super if defined?(::GrapeSwagger)
 
       options = options.dup
+      hide_doc = options.delete(:hide_documentation_path) { true }
       options[:oas_doc_version] ||= :oas2
       options[:oas_mount_path] ||= options[:mount_path] || "/swagger_doc.json"
-      add_oas_documentation(**options)
+      add_oas_documentation(hide_documentation_path: hide_doc, **options)
     end
 
     private

--- a/lib/grape_oas/documentation_extension.rb
+++ b/lib/grape_oas/documentation_extension.rb
@@ -3,9 +3,7 @@
 module GrapeOAS
   module DocumentationExtension
     # Primary entry for grape-oas documentation
-    def add_oas_documentation(**options)
-      return if options.delete(:hide_documentation_path)
-
+    def add_oas_documentation(hide_documentation_path: true, **options)
       # Prefer grape-oas namespaced options to avoid clashing with grape-swagger
       default_mount_path = options.delete(:oas_mount_path) ||
                            options.delete(:mount_path) ||
@@ -25,13 +23,13 @@ module GrapeOAS
       api = self
 
       mount_paths.each do |key, path|
-        add_documentation_routes(path, key, default_format, cache_control, etag_value, options, api)
+        add_documentation_routes(path, key, default_format, cache_control, etag_value, options, api, hidden: hide_documentation_path)
       end
     end
 
-    def add_documentation_routes(path, key, default_format, cache_control, etag_value, options, api)
+    def add_documentation_routes(path, key, default_format, cache_control, etag_value, options, api, hidden: false)
       # Main route without namespace filter
-      add_route(path) do
+      add_route(path, hidden: hidden) do
         GrapeOAS::DocumentationExtension.generate_documentation(
           self, api, key, default_format, cache_control, etag_value, options, nil,
         )
@@ -39,7 +37,7 @@ module GrapeOAS
 
       # Route with namespace filter: /swagger_doc/:namespace
       # Supports nested namespaces via *namespace (catches slashes)
-      add_route("#{path}/*namespace") do
+      add_route("#{path}/*namespace", hidden: hidden) do
         namespace_filter = params[:namespace]&.sub(/\.json$/, "")
         GrapeOAS::DocumentationExtension.generate_documentation(
           self, api, key, default_format, cache_control, etag_value, options, namespace_filter,
@@ -89,10 +87,10 @@ module GrapeOAS
     private
 
     # Minimal route mounting helper
-    def add_route(path, &block)
+    def add_route(path, hidden: false, &block)
       api_class = self
       namespace do
-        get(path) { instance_exec(api_class, &block) }
+        get(path, hidden: hidden) { instance_exec(api_class, &block) }
       end
     end
 

--- a/test/integration/documentation_extension_test.rb
+++ b/test/integration/documentation_extension_test.rb
@@ -317,4 +317,33 @@ class DocumentationExtensionTest < Minitest::Test
 
     assert_equal "3.0.0", body["openapi"]
   end
+
+  class HideDocPathAPI < Grape::API
+    format :json
+    get "ping" do; end
+    add_oas_documentation(oas_mount_path: "/spec")
+  end
+
+  class ShowDocPathAPI < Grape::API
+    format :json
+    get "ping" do; end
+    add_oas_documentation(oas_mount_path: "/spec", hide_documentation_path: false)
+  end
+
+  def test_documentation_paths_hidden_by_default
+    resp = Rack::MockRequest.new(HideDocPathAPI).get("/spec")
+    body = JSON.parse(resp.body)
+
+    refute_includes body["paths"].keys, "/spec"
+    refute_includes body["paths"].keys, "/spec/{namespace}"
+    assert_includes body["paths"].keys, "/ping"
+  end
+
+  def test_documentation_paths_included_when_not_hidden
+    resp = Rack::MockRequest.new(ShowDocPathAPI).get("/spec")
+    body = JSON.parse(resp.body)
+
+    assert body["paths"].keys.any? { |p| p.start_with?("/spec") }
+    assert_includes body["paths"].keys, "/ping"
+  end
 end

--- a/test/integration/documentation_extension_test.rb
+++ b/test/integration/documentation_extension_test.rb
@@ -346,4 +346,32 @@ class DocumentationExtensionTest < Minitest::Test
     assert body["paths"].keys.any? { |p| p.start_with?("/spec") }
     assert_includes body["paths"].keys, "/ping"
   end
+
+  class SwaggerCompatHideAPI < Grape::API
+    format :json
+    get "ping" do; end
+    add_swagger_documentation(mount_path: "/swagger_doc.json")
+  end
+
+  class SwaggerCompatShowAPI < Grape::API
+    format :json
+    get "ping" do; end
+    add_swagger_documentation(mount_path: "/swagger_doc.json", hide_documentation_path: false)
+  end
+
+  def test_swagger_documentation_paths_hidden_by_default
+    resp = Rack::MockRequest.new(SwaggerCompatHideAPI).get("/swagger_doc.json")
+    body = JSON.parse(resp.body)
+
+    refute body["paths"].keys.any? { |p| p.start_with?("/swagger_doc") }
+    assert_includes body["paths"].keys, "/ping"
+  end
+
+  def test_swagger_documentation_paths_shown_when_opted_out
+    resp = Rack::MockRequest.new(SwaggerCompatShowAPI).get("/swagger_doc.json")
+    body = JSON.parse(resp.body)
+
+    assert body["paths"].keys.any? { |p| p.start_with?("/swagger_doc") }
+    assert_includes body["paths"].keys, "/ping"
+  end
 end

--- a/test/integration/documentation_extension_test.rb
+++ b/test/integration/documentation_extension_test.rb
@@ -320,13 +320,13 @@ class DocumentationExtensionTest < Minitest::Test
 
   class HideDocPathAPI < Grape::API
     format :json
-    get "ping" do; end
+    get("ping") { nil }
     add_oas_documentation(oas_mount_path: "/spec")
   end
 
   class ShowDocPathAPI < Grape::API
     format :json
-    get "ping" do; end
+    get("ping") { nil }
     add_oas_documentation(oas_mount_path: "/spec", hide_documentation_path: false)
   end
 
@@ -343,19 +343,19 @@ class DocumentationExtensionTest < Minitest::Test
     resp = Rack::MockRequest.new(ShowDocPathAPI).get("/spec")
     body = JSON.parse(resp.body)
 
-    assert body["paths"].keys.any? { |p| p.start_with?("/spec") }
+    assert(body["paths"].keys.any? { |p| p.start_with?("/spec") })
     assert_includes body["paths"].keys, "/ping"
   end
 
   class SwaggerCompatHideAPI < Grape::API
     format :json
-    get "ping" do; end
+    get("ping") { nil }
     add_swagger_documentation(mount_path: "/swagger_doc.json")
   end
 
   class SwaggerCompatShowAPI < Grape::API
     format :json
-    get "ping" do; end
+    get("ping") { nil }
     add_swagger_documentation(mount_path: "/swagger_doc.json", hide_documentation_path: false)
   end
 
@@ -363,7 +363,7 @@ class DocumentationExtensionTest < Minitest::Test
     resp = Rack::MockRequest.new(SwaggerCompatHideAPI).get("/swagger_doc.json")
     body = JSON.parse(resp.body)
 
-    refute body["paths"].keys.any? { |p| p.start_with?("/swagger_doc") }
+    refute(body["paths"].keys.any? { |p| p.start_with?("/swagger_doc") })
     assert_includes body["paths"].keys, "/ping"
   end
 
@@ -371,7 +371,7 @@ class DocumentationExtensionTest < Minitest::Test
     resp = Rack::MockRequest.new(SwaggerCompatShowAPI).get("/swagger_doc.json")
     body = JSON.parse(resp.body)
 
-    assert body["paths"].keys.any? { |p| p.start_with?("/swagger_doc") }
+    assert(body["paths"].keys.any? { |p| p.start_with?("/swagger_doc") })
     assert_includes body["paths"].keys, "/ping"
   end
 end


### PR DESCRIPTION
## Problem

grape-oas was including its own spec endpoints (`/swagger_doc`, `/swagger_doc/*namespace`)
in the generated output. This pollutes the spec with meta-endpoints that API consumers
should not see.

## Fix

`hide_documentation_path` now defaults to `true` (matching grape-swagger behavior).
The option is a kwarg on `add_oas_documentation` and sets `hidden: true` on the Grape
routes themselves, reusing the existing route-filtering mechanism rather than tracking
paths separately.

To opt in to the old behavior: `add_oas_documentation(hide_documentation_path: false)`