### PR TITLE
Fix: convert wildcard (*param) path segments to valid OAS {param} syntax

### DIFF
--- a/lib/grape_oas/api_model_builders/path.rb
+++ b/lib/grape_oas/api_model_builders/path.rb
@@ -10,6 +10,11 @@ module GrapeOAS
       PATH_PARAMETER_PATTERN = %r{(?<=/):(?<param>[^/]+)}
       private_constant :PATH_PARAMETER_PATTERN
 
+      # Matches Grape's wildcard segments: /?*param or /*param
+      # The optional ? before * is Grape's syntax for an optional leading slash
+      WILDCARD_PARAMETER_PATTERN = /\??\*(?<param>[^\/()]+)/
+      private_constant :WILDCARD_PARAMETER_PATTERN
+
       NORMALIZED_PLACEHOLDER = /\{[^}]+\}/
       private_constant :NORMALIZED_PLACEHOLDER
 
@@ -98,7 +103,8 @@ module GrapeOAS
       def sanitize_path(path)
         path
           .gsub(EXTENSION_PATTERN, "") # Remove format extensions like (.json)
-          .gsub(PATH_PARAMETER_PATTERN, "{\\k<param>}") # Replace named parameters with curly braces
+          .gsub(WILDCARD_PARAMETER_PATTERN, "{\\k<param>}") # Replace *param / /?*param with {param}
+          .gsub(PATH_PARAMETER_PATTERN, "{\\k<param>}") # Replace :param with {param}
       end
 
       def normalize_template(path)

--- a/lib/grape_oas/api_model_builders/request_params.rb
+++ b/lib/grape_oas/api_model_builders/request_params.rb
@@ -3,7 +3,7 @@
 module GrapeOAS
   module ApiModelBuilders
     class RequestParams
-      ROUTE_PARAM_REGEX = /(?<=:)\w+/
+      ROUTE_PARAM_REGEX = /(?<=[:*])\w+/
 
       attr_reader :api, :route, :path_param_name_map
 

--- a/test/grape_oas/api_model_builders/path_test.rb
+++ b/test/grape_oas/api_model_builders/path_test.rb
@@ -267,6 +267,24 @@ module GrapeOAS
         refute_includes templates, "/users"
         refute_includes templates, "/users/comments"
       end
+
+      def test_wildcard_path_converted_to_oas_template
+        api_class = Class.new(Grape::API) do
+          format :json
+          get "files/*path" do; end
+          get "a/:id/*rest" do; end
+          get "*all" do; end
+        end
+
+        builder = Path.new(api: @api, routes: api_class.routes)
+        builder.build
+
+        templates = @api.paths.map(&:template)
+
+        assert_includes templates, "/files/{path}"
+        assert_includes templates, "/a/{id}/{rest}"
+        assert_includes templates, "/{all}"
+      end
     end
   end
 end

--- a/test/grape_oas/api_model_builders/request_params_location_test.rb
+++ b/test/grape_oas/api_model_builders/request_params_location_test.rb
@@ -337,6 +337,28 @@ module GrapeOAS
         assert_includes path_names, "user_id"
       end
 
+      # === Wildcard path param location ===
+
+      def test_wildcard_param_classified_as_path
+        api_class = Class.new(Grape::API) do
+          format :json
+          params do
+            requires :path, type: String
+          end
+          get "files/*path" do
+            {}
+          end
+        end
+
+        route = api_class.routes.first
+        op = build_operation(route, api_class)
+
+        path_params = op.parameters.select { |p| p.location == "path" }
+
+        assert(path_params.any? { |p| p.name == "path" },
+               "wildcard *path param should be classified as path location, not query")
+      end
+
       private
 
       def build_operation(route, app)


### PR DESCRIPTION
## Problem

Grape wildcard routes (e.g. `get "files/*path"`) were emitted as
`/files/?*param` in the generated spec — invalid OAS syntax that
breaks validators and tooling like Swagger UI and Redoc.

## Fix

Added a sanitization step that converts Grape's wildcard segments
(`/?*param`, `/*param`) to `{param}` before building the path template.

## Note

OAS 2.0 and 3.0 have no native equivalent for catch-all path parameters
that span multiple segments (including slashes). `{param}` formally
matches only a single segment, so this conversion is semantically lossy.
It is however the best valid approximation available in OAS.

grape-swagger has the same gap — it only handles `:param` → `{param}`
and leaves wildcard segments unsanitized.