### PR TITLE
Fix: respect documentation: { hidden: true } on entity exposures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#78](https://github.com/numbata/grape-oas/pull/78): Fix: use empty schema for undocumented responses instead of `{ type: string }` - [@bogdan](https://github.com/bogdan).
 - [#74](https://github.com/numbata/grape-oas/pull/74): Fix BigDecimal range bounds serializing as JSON strings - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#76](https://github.com/numbata/grape-oas/pull/76): Emit OAS-version-correct schema for file types - [@olivier-thatch](https://github.com/olivier-thatch).
+- [#82](https://github.com/numbata/grape-oas/pull/82): Fix: respect `documentation: { hidden: true }` on entity exposures - [@bogdan](https://github.com/bogdan).
 * Your contribution here
 
 ### Changed

--- a/lib/grape_oas/introspectors/entity_introspector_support/exposure_processor.rb
+++ b/lib/grape_oas/introspectors/entity_introspector_support/exposure_processor.rb
@@ -73,8 +73,9 @@ module GrapeOAS
         #
         # @param exposure the entity exposure
         # @return [Boolean] true if exposed
-        def exposed?(_exposure)
-          true
+        def exposed?(exposure)
+          doc = normalize_doc_keys(exposure.documentation || {})
+          !doc[:hidden]
         end
 
         # Checks if an exposure is conditional.

--- a/lib/grape_oas/introspectors/entity_introspector_support/exposure_processor.rb
+++ b/lib/grape_oas/introspectors/entity_introspector_support/exposure_processor.rb
@@ -181,6 +181,8 @@ module GrapeOAS
           nesting_accum = {}
           nesting_required = Hash.new { |h, k| h[k] = [] }
           Array(exposure.nested_exposures).each do |child_exposure|
+            next unless exposed?(child_exposure)
+
             if nesting_exposure?(child_exposure)
               key = child_exposure.key.to_s
               child_doc = normalize_doc_keys(child_exposure.documentation || {})

--- a/lib/grape_oas/introspectors/entity_introspector_support/exposure_processor.rb
+++ b/lib/grape_oas/introspectors/entity_introspector_support/exposure_processor.rb
@@ -19,8 +19,6 @@ module GrapeOAS
         # @param schema [ApiModel::Schema] the schema to populate
         def add_exposures_to_schema(schema)
           exposures.each do |exposure|
-            next unless exposed?(exposure)
-
             add_exposure_to_schema(schema, exposure)
           end
         end
@@ -75,7 +73,9 @@ module GrapeOAS
         # @return [Boolean] true if exposed
         def exposed?(exposure)
           doc = normalize_doc_keys(exposure.documentation || {})
-          !doc[:hidden]
+          hidden = doc[:hidden]
+          hidden = hidden.call if hidden.respond_to?(:call)
+          !hidden
         end
 
         # Checks if an exposure is conditional.
@@ -129,6 +129,8 @@ module GrapeOAS
         end
 
         def add_exposure_to_schema(schema, exposure)
+          return unless exposed?(exposure)
+
           doc = normalize_doc_keys(exposure.documentation || {})
           opts = exposure_options(exposure)
 

--- a/test/grape_oas/introspectors/entity_introspector_edge_cases_test.rb
+++ b/test/grape_oas/introspectors/entity_introspector_edge_cases_test.rb
@@ -50,6 +50,24 @@ module GrapeOAS
         assert_includes wrapper.properties.keys, "visible_nested"
       end
 
+      class HiddenNestingEntity < Grape::Entity
+        expose :wrapper do
+          expose :internal_group, documentation: { hidden: true } do
+            expose :secret_field, documentation: { type: String }
+          end
+          expose :public_field, documentation: { type: String }
+        end
+      end
+
+      def test_hidden_nesting_exposure_excluded
+        schema = EntityIntrospector.new(HiddenNestingEntity).build_schema
+
+        wrapper = schema.properties["wrapper"]
+
+        refute_includes wrapper.properties.keys, "internal_group"
+        assert_includes wrapper.properties.keys, "public_field"
+      end
+
       class ProcHiddenEntity < Grape::Entity
         expose :visible, documentation: { type: String }
         expose :secret, documentation: { type: String, hidden: proc { true } }

--- a/test/grape_oas/introspectors/entity_introspector_edge_cases_test.rb
+++ b/test/grape_oas/introspectors/entity_introspector_edge_cases_test.rb
@@ -45,6 +45,7 @@ module GrapeOAS
         schema = EntityIntrospector.new(NestedHiddenEntity).build_schema
 
         wrapper = schema.properties["wrapper"]
+
         refute_includes wrapper.properties.keys, "secret"
         assert_includes wrapper.properties.keys, "visible_nested"
       end

--- a/test/grape_oas/introspectors/entity_introspector_edge_cases_test.rb
+++ b/test/grape_oas/introspectors/entity_introspector_edge_cases_test.rb
@@ -32,6 +32,37 @@ module GrapeOAS
         refute_includes schema.properties.keys, "hidden_field"
       end
 
+      # === Entity with nested hidden exposures ===
+
+      class NestedHiddenEntity < Grape::Entity
+        expose :wrapper do
+          expose :secret, documentation: { type: String, hidden: true }
+          expose :visible_nested, documentation: { type: String }
+        end
+      end
+
+      def test_nested_hidden_property_handling
+        schema = EntityIntrospector.new(NestedHiddenEntity).build_schema
+
+        wrapper = schema.properties["wrapper"]
+        refute_includes wrapper.properties.keys, "secret"
+        assert_includes wrapper.properties.keys, "visible_nested"
+      end
+
+      class ProcHiddenEntity < Grape::Entity
+        expose :visible, documentation: { type: String }
+        expose :secret, documentation: { type: String, hidden: proc { true } }
+        expose :shown, documentation: { type: String, hidden: proc { false } }
+      end
+
+      def test_hidden_proc_property_handling
+        schema = EntityIntrospector.new(ProcHiddenEntity).build_schema
+
+        assert_includes schema.properties.keys, "visible"
+        refute_includes schema.properties.keys, "secret"
+        assert_includes schema.properties.keys, "shown"
+      end
+
       # === Entity with string type references (grape-swagger #427) ===
 
       class ReferencedEntity < Grape::Entity

--- a/test/grape_oas/introspectors/entity_introspector_edge_cases_test.rb
+++ b/test/grape_oas/introspectors/entity_introspector_edge_cases_test.rb
@@ -28,9 +28,8 @@ module GrapeOAS
       def test_hidden_property_handling
         schema = EntityIntrospector.new(HiddenPropertiesEntity).build_schema
 
-        # Both properties should be in the schema (hidden is for swagger-ui, not schema)
         assert_includes schema.properties.keys, "visible"
-        assert_includes schema.properties.keys, "hidden_field"
+        refute_includes schema.properties.keys, "hidden_field"
       end
 
       # === Entity with string type references (grape-swagger #427) ===


### PR DESCRIPTION
## Problem

Fixes #77

Exposures marked with `documentation: { hidden: true }` were included
in the generated schema. `ExposureProcessor#exposed?` always returned
`true` without checking the documentation hash.

## Fix

`exposed?` now reads the `hidden` key from the normalized documentation
hash and excludes the field when it is `true`.

## Note

This is a behavior change from the original design, which treated
`hidden` as a Swagger UI display hint rather than a schema filter
(see commit 6084980). The fix aligns grape-oas with grape-swagger,
which excludes hidden fields from the spec entirely.