### PR TITLE
Fix: Honor is_array: true on plain-entity response branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#76](https://github.com/numbata/grape-oas/pull/76): Emit OAS-version-correct schema for file types - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#82](https://github.com/numbata/grape-oas/pull/82): Fix: respect `documentation: { hidden: true }` on entity exposures - [@bogdan](https://github.com/bogdan).
 - [#80](https://github.com/numbata/grape-oas/pull/80): Fix: hide documentation routes from generated spec by default - [@bogdan](https://github.com/bogdan).
+- [#85](https://github.com/numbata/grape-oas/pull/85): Honor `is_array: true` on the plain-entity response branch - [@abeljim8am](https://github.com/abeljim8am).
 * Your contribution here
 
 ### Changed

--- a/lib/grape_oas/api_model_builders/response.rb
+++ b/lib/grape_oas/api_model_builders/response.rb
@@ -177,6 +177,7 @@ module GrapeOAS
 
       def build_response_from_spec(spec)
         entity_schema = build_schema(spec[:entity])
+        entity_schema = array_schema(entity_schema) if spec[:is_array]
         schema = wrap_with_root(entity_schema, spec[:entity], is_array: spec[:is_array])
         media_types = Array(response_content_types).map do |mime|
           build_media_type(

--- a/test/grape_oas/api_model_builders/response_edge_cases_test.rb
+++ b/test/grape_oas/api_model_builders/response_edge_cases_test.rb
@@ -167,8 +167,60 @@ module GrapeOAS
         refute_nil success
         schema = success.media_types.first.schema
 
-        # NOTE: is_array handling depends on implementation
-        refute_nil schema
+        assert_equal "array", schema.type
+        refute_nil schema.items
+        assert_equal "object", schema.items.type
+        assert_equal "GrapeOAS::ApiModelBuilders::ResponseEdgeCasesTest::ItemEntity",
+                     schema.items.canonical_name
+      end
+
+      def test_response_with_root_and_array_of_entities_wraps_array_under_pluralized_root
+        api_class = Class.new(Grape::API) do
+          format :json
+          route_setting :swagger, root: true
+          desc "List items",
+               success: { code: 200, model: ResponseEdgeCasesTest::ItemEntity, is_array: true }
+          get "items" do
+            []
+          end
+        end
+
+        route = api_class.routes.first
+        builder = Response.new(api: @api, route: route)
+        responses = builder.build
+
+        success = responses.find { |r| r.http_status == "200" }
+        schema = success.media_types.first.schema
+        rooted_schema = schema.properties["items"]
+
+        assert_equal "object", schema.type
+        assert_equal ["items"], schema.properties.keys
+        assert_equal "array", rooted_schema.type
+        assert_equal "object", rooted_schema.items.type
+        assert_equal "GrapeOAS::ApiModelBuilders::ResponseEdgeCasesTest::ItemEntity",
+                     rooted_schema.items.canonical_name
+      end
+
+      def test_response_with_entity_no_is_array_emits_plain_object
+        api_class = Class.new(Grape::API) do
+          format :json
+          desc "Get item",
+               success: { code: 200, model: ResponseEdgeCasesTest::ItemEntity }
+          get "items/:id" do
+            {}
+          end
+        end
+
+        route = api_class.routes.first
+        builder = Response.new(api: @api, route: route)
+        responses = builder.build
+
+        success = responses.find { |r| r.http_status == "200" }
+        schema = success.media_types.first.schema
+
+        assert_equal "object", schema.type
+        assert_equal "GrapeOAS::ApiModelBuilders::ResponseEdgeCasesTest::ItemEntity",
+                     schema.canonical_name
       end
 
       # === Empty success (no entity) ===


### PR DESCRIPTION
## Summary

`entity: MyEntity, is_array: true` (without `using:`, `as:`, or `one_of:`)
emits a bare `$ref` instead of an array wrapping the entity. The
`using:`-branch already wraps correctly; the plain-entity branch did not.

### Before
```yaml
schema:
  $ref: "#/components/schemas/ItemEntity"
```

### After
```yaml
schema:
  type: array
  items:
    $ref: "#/components/schemas/ItemEntity"
```

## What changed

In `build_response_from_spec`, wrap the resolved entity schema in an array
schema when `spec[:is_array]` is truthy, mirroring the `using:` branch.