### PR TITLE
Feat: Add configurable GrapeOAS.entity_exposure_required_default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#96](https://github.com/numbata/grape-oas/pull/96): Pin rubocop versions and add performance/packaging/rake plugins - [@numbata](https://github.com/numbata).
 - [#92](https://github.com/numbata/grape-oas/pull/92): Add cross-tool AI-agent contributor guidance and tighten gem file packaging - [@numbata](https://github.com/numbata).
+- [#89](https://github.com/numbata/grape-oas/pull/89): Add configurable `GrapeOAS.entity_exposure_required_default` (default `true`) that controls whether entity exposures without an explicit `documentation: { required: ... }` key are marked required. Default behavior is byte-identical to prior output; setting it to `false` opts out so only explicitly-required exposures end up in the `required` array. Conditional exposures and explicit `required:` values are unaffected - [@abeljim8am](https://github.com/abeljim8am).
 - Your contribution here
 
 ### Fixed
@@ -26,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#85](https://github.com/numbata/grape-oas/pull/85): Honor `is_array: true` on the plain-entity response branch - [@abeljim8am](https://github.com/abeljim8am).
 - [#87](https://github.com/numbata/grape-oas/pull/87): Fix `SchemaIndexer#index_schema` to recurse into `schema.items` so entities reachable only through an array wrapper (e.g. a property declared as `Array<OtherEntity>`) are included in the indexed schemas set - [@abeljim8am](https://github.com/abeljim8am).
 - [#102](https://github.com/numbata/grape-oas/pull/102): Fix: nullable entity ref must not mutate shared cached schema - [@bogdan](https://github.com/bogdan).
-* Your contribution here
+- Your contribution here
 
 ### Changed
 

--- a/lib/grape_oas.rb
+++ b/lib/grape_oas.rb
@@ -68,6 +68,30 @@ module GrapeOAS
 
   module_function :logger, :logger=
 
+  # Whether entity exposures without an explicit `required:` documentation key
+  # default to required. When `true` (default), unconditional exposures are
+  # marked required — byte-identical to prior output. When `false`, they are
+  # omitted from `required` unless `documentation: { required: true }` is set.
+  # Conditional exposures and explicit `required:` values are unaffected.
+  #
+  # @return [Boolean]
+  def entity_exposure_required_default
+    return true if @entity_exposure_required_default.nil?
+
+    @entity_exposure_required_default
+  end
+
+  # @param value [true, false, nil] `nil` resets to the default (`true`)
+  def entity_exposure_required_default=(value)
+    unless value.nil? || value == true || value == false
+      raise ArgumentError, "entity_exposure_required_default must be true, false, or nil (got #{value.class})"
+    end
+
+    @entity_exposure_required_default = value
+  end
+
+  module_function :entity_exposure_required_default, :entity_exposure_required_default=
+
   # Returns the global introspector registry.
   #
   # The registry manages introspectors that build schemas from various sources

--- a/lib/grape_oas/introspectors/entity_introspector_support/exposure_processor.rb
+++ b/lib/grape_oas/introspectors/entity_introspector_support/exposure_processor.rb
@@ -110,7 +110,8 @@ module GrapeOAS
 
         # Determines whether a property should be marked required.
         # Explicit doc[:required] takes precedence; conditional exposures
-        # default to false; unconditional exposures default to true.
+        # default to false; unconditional exposures fall back to
+        # GrapeOAS.entity_exposure_required_default (default `true`).
         #
         # @param doc [Hash] normalized documentation hash
         # @param exposure the entity exposure
@@ -119,7 +120,7 @@ module GrapeOAS
           return doc[:required] unless doc[:required].nil?
           return false if conditional?(exposure)
 
-          true
+          GrapeOAS.entity_exposure_required_default
         end
 
         private

--- a/test/e2e/generate_exposure_required_default_config_test.rb
+++ b/test/e2e/generate_exposure_required_default_config_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GrapeOAS
+  class GenerateExposureRequiredDefaultConfigTest < Minitest::Test
+    class UserEntity < Grape::Entity
+      expose :id, documentation: { type: Integer }
+      expose :name, documentation: { type: String }
+      expose :nickname, documentation: { type: String, required: false }
+      expose :email, documentation: { type: String, required: true }
+      expose :maybe, documentation: { type: String }, if: ->(_o, _opts) { true }
+    end
+
+    class API < Grape::API
+      format :json
+
+      desc "Get a user" do
+        success UserEntity
+      end
+      get "/users/:id" do
+        {}
+      end
+    end
+
+    def teardown
+      GrapeOAS.entity_exposure_required_default = nil
+    end
+
+    # === Default-behavior regression guard: flag defaults to true ===
+
+    def test_default_flag_marks_unconditional_exposures_required
+      GrapeOAS.entity_exposure_required_default = nil
+
+      schema = GrapeOAS.generate(app: API, schema_type: :oas3)
+      required = schema.dig("components", "schemas", "GrapeOAS_GenerateExposureRequiredDefaultConfigTest_UserEntity", "required")
+
+      assert_includes required, "id"
+      assert_includes required, "name"
+      assert_includes required, "email"
+      refute_includes required, "nickname", "explicit required: false must win"
+      refute_includes required, "maybe", "conditional exposures are never required by default"
+    end
+
+    # === Opt-out: flag=false strips default-required from unconditional exposures ===
+
+    def test_flag_false_does_not_mark_unconditional_exposures_required
+      GrapeOAS.entity_exposure_required_default = false
+
+      schema = GrapeOAS.generate(app: API, schema_type: :oas3)
+      component = schema.dig("components", "schemas", "GrapeOAS_GenerateExposureRequiredDefaultConfigTest_UserEntity")
+      required = component["required"] || []
+
+      refute_includes required, "id"
+      refute_includes required, "name"
+      refute_includes required, "nickname"
+      refute_includes required, "maybe"
+      assert_includes required, "email", "explicit required: true must still mark the property required"
+    end
+
+    # === Explicit flag=true matches default ===
+
+    def test_flag_true_matches_default_behavior
+      GrapeOAS.entity_exposure_required_default = true
+
+      schema = GrapeOAS.generate(app: API, schema_type: :oas3)
+      required = schema.dig("components", "schemas", "GrapeOAS_GenerateExposureRequiredDefaultConfigTest_UserEntity", "required")
+
+      assert_includes required, "id"
+      assert_includes required, "name"
+      assert_includes required, "email"
+      refute_includes required, "nickname"
+      refute_includes required, "maybe"
+    end
+  end
+end

--- a/test/grape_oas/introspectors/entity_introspector_support/exposure_processor_test.rb
+++ b/test/grape_oas/introspectors/entity_introspector_support/exposure_processor_test.rb
@@ -215,6 +215,81 @@ module GrapeOAS
           assert_equal %w[a b], items.enum
         end
       end
+
+      # Unit tests for determine_required respecting GrapeOAS.entity_exposure_required_default
+      class ExposureProcessorDetermineRequiredTest < Minitest::Test
+        def setup
+          @processor = ExposureProcessor.new(Class.new, stack: [], registry: {})
+        end
+
+        def teardown
+          GrapeOAS.entity_exposure_required_default = nil
+        end
+
+        def build_exposure(conditional: false)
+          exposure = Object.new
+          conditions = conditional ? [->(_o, _opts) { true }] : []
+          exposure.instance_variable_set(:@conditions, conditions)
+          exposure
+        end
+
+        # === Explicit required: always wins regardless of config flag ===
+
+        def test_explicit_required_true_wins_when_flag_is_false
+          GrapeOAS.entity_exposure_required_default = false
+
+          assert @processor.determine_required({ required: true }, build_exposure)
+        end
+
+        def test_explicit_required_false_wins_when_flag_is_true
+          GrapeOAS.entity_exposure_required_default = true
+
+          refute @processor.determine_required({ required: false }, build_exposure)
+        end
+
+        def test_explicit_required_true_on_conditional_wins_when_flag_is_false
+          GrapeOAS.entity_exposure_required_default = false
+          exposure = build_exposure(conditional: true)
+
+          assert @processor.determine_required({ required: true }, exposure)
+        end
+
+        # === Conditional exposures stay false regardless of flag ===
+
+        def test_conditional_exposure_is_false_when_flag_is_true
+          GrapeOAS.entity_exposure_required_default = true
+          exposure = build_exposure(conditional: true)
+
+          refute @processor.determine_required({}, exposure)
+        end
+
+        def test_conditional_exposure_is_false_when_flag_is_false
+          GrapeOAS.entity_exposure_required_default = false
+          exposure = build_exposure(conditional: true)
+
+          refute @processor.determine_required({}, exposure)
+        end
+
+        # === Unconditional exposures without explicit required: consult the flag ===
+
+        def test_unconditional_exposure_is_required_when_flag_is_true_default
+          GrapeOAS.entity_exposure_required_default = nil
+
+          assert @processor.determine_required({}, build_exposure)
+        end
+
+        def test_unconditional_exposure_is_not_required_when_flag_is_false
+          GrapeOAS.entity_exposure_required_default = false
+
+          refute @processor.determine_required({}, build_exposure)
+        end
+
+        def test_unconditional_exposure_is_required_when_flag_explicitly_true
+          GrapeOAS.entity_exposure_required_default = true
+
+          assert @processor.determine_required({}, build_exposure)
+        end
+      end
     end
   end
 end

--- a/test/grape_oas/oas_test.rb
+++ b/test/grape_oas/oas_test.rb
@@ -71,4 +71,46 @@ class GrapeOASTest < Minitest::Test
   ensure
     GrapeOAS.logger = nil
   end
+
+  def test_entity_exposure_required_default_defaults_to_true
+    GrapeOAS.entity_exposure_required_default = nil
+
+    assert GrapeOAS.entity_exposure_required_default
+  ensure
+    GrapeOAS.entity_exposure_required_default = nil
+  end
+
+  def test_entity_exposure_required_default_setter_accepts_false
+    GrapeOAS.entity_exposure_required_default = false
+
+    refute GrapeOAS.entity_exposure_required_default
+  ensure
+    GrapeOAS.entity_exposure_required_default = nil
+  end
+
+  def test_entity_exposure_required_default_setter_accepts_true
+    GrapeOAS.entity_exposure_required_default = false
+    GrapeOAS.entity_exposure_required_default = true
+
+    assert GrapeOAS.entity_exposure_required_default
+  ensure
+    GrapeOAS.entity_exposure_required_default = nil
+  end
+
+  def test_entity_exposure_required_default_setter_accepts_nil_to_reset_to_default
+    GrapeOAS.entity_exposure_required_default = false
+    GrapeOAS.entity_exposure_required_default = nil
+
+    assert GrapeOAS.entity_exposure_required_default
+  ensure
+    GrapeOAS.entity_exposure_required_default = nil
+  end
+
+  def test_entity_exposure_required_default_setter_raises_for_non_boolean
+    error = assert_raises(ArgumentError) { GrapeOAS.entity_exposure_required_default = "true" }
+    assert_match(/must be true, false, or nil/, error.message)
+    assert_match(/String/, error.message)
+  ensure
+    GrapeOAS.entity_exposure_required_default = nil
+  end
 end


### PR DESCRIPTION
## Summary

Every `expose :foo` without an explicit
`documentation: { required: ... }` is currently marked required. This is
the outlier in the Ruby/OpenAPI ecosystem (grape-swagger and most other
generators default exposures to optional unless `required: true` is set).

This PR adds a config flag so apps can opt out without changing the
existing default. A future major version could flip the default safely
on the back of this flag.

## What changed

Added `GrapeOAS.entity_exposure_required_default` (default `true`).
`ExposureProcessor#determine_required` consults the flag when an exposure
has no explicit `required:` value.

| Configuration | Exposure | Required? |
|---|---|---|
| `true` (default) | `expose :foo` | yes |
| `false` | `expose :foo` | no |
| Either | `expose :foo, documentation: { required: true }` | yes |
| Either | `expose :foo, documentation: { required: false }` | no |

Conditional exposures (`if:`/`unless:`) and explicit `required:` values
are unaffected.