### PR TITLE
Feat: Consult type_resolvers registry for entity exposures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#96](https://github.com/numbata/grape-oas/pull/96): Pin rubocop versions and add performance/packaging/rake plugins - [@numbata](https://github.com/numbata).
 - [#92](https://github.com/numbata/grape-oas/pull/92): Add cross-tool AI-agent contributor guidance and tighten gem file packaging - [@numbata](https://github.com/numbata).
+- Entity exposures whose declared type is a class that is neither a `Grape::Entity` nor a known primitive now consult `GrapeOAS.type_resolvers` before falling back to `{ type: "string" }`. Apps can register a custom `TypeResolvers::Base` implementation to supply a richer schema (e.g. UUID, Dry::Types wrappers, app-specific value objects) for entity exposures, mirroring the first-match-wins semantics already used for request parameters.
 - Your contribution here
 
 ### Fixed
@@ -22,12 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#76](https://github.com/numbata/grape-oas/pull/76): Emit OAS-version-correct schema for file types - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#82](https://github.com/numbata/grape-oas/pull/82): Fix: respect `documentation: { hidden: true }` on entity exposures - [@bogdan](https://github.com/bogdan).
 - [#80](https://github.com/numbata/grape-oas/pull/80): Fix: hide documentation routes from generated spec by default - [@bogdan](https://github.com/bogdan).
-* Your contribution here
+- Your contribution here
 
 ### Changed
 
 - [#95](https://github.com/numbata/grape-oas/pull/95): Entity exposures now consult `GrapeOAS.type_resolvers` - [@numbata](https://github.com/numbata).
-* Your contribution here
+- Your contribution here
 
 ## [1.4.0] - 2026-04-23
 

--- a/lib/grape_oas/introspectors/entity_introspector_support/type_schema_resolver.rb
+++ b/lib/grape_oas/introspectors/entity_introspector_support/type_schema_resolver.rb
@@ -94,7 +94,9 @@ module GrapeOAS
           if defined?(Grape::Entity) && type <= Grape::Entity
             GrapeOAS.introspectors.build_schema(type, stack: @stack, registry: @registry)
           else
-            GrapeOAS.type_resolvers.build_schema(type)
+            build_schema_for_primitive(type) ||
+              GrapeOAS.type_resolvers.build_schema(type) ||
+              default_string_schema
           end
         end
 

--- a/test/grape_oas/introspectors/entity_introspector_support/type_schema_resolver_test.rb
+++ b/test/grape_oas/introspectors/entity_introspector_support/type_schema_resolver_test.rb
@@ -159,6 +159,94 @@ module GrapeOAS
         # subsequently raises NameError (e.g. concurrent autoload failure). This cannot be
         # triggered deterministically in a unit test without unsafe global monkey-patching
         # of Object.const_get. Accepted as an untestable defensive branch.
+
+        # === Custom type resolver registry integration ===
+        #
+        # When an exposure declares a class that is not a Grape::Entity and not a
+        # known primitive, build_exposure_base_schema consults GrapeOAS.type_resolvers
+        # before falling back to { type: "string" }.
+
+        # Marker class used to target a custom resolver. Not a Grape::Entity, not a
+        # known primitive — so without a registered resolver, falls back to string.
+        CustomTypeMarker = Class.new
+
+        class CustomTypeMarkerResolver
+          extend GrapeOAS::TypeResolvers::Base
+
+          def self.handles?(type)
+            type == CustomTypeMarker
+          end
+
+          def self.build_schema(_type)
+            ApiModel::Schema.new(type: Constants::SchemaTypes::STRING, format: "custom-format")
+          end
+        end
+
+        def test_class_type_consults_type_resolvers_registry_before_string_fallback
+          with_isolated_type_resolvers do
+            GrapeOAS.type_resolvers.register(CustomTypeMarkerResolver)
+
+            schema = @resolver.build_exposure_base_schema(CustomTypeMarker)
+
+            assert_equal Constants::SchemaTypes::STRING, schema.type
+            assert_equal "custom-format", schema.format
+          end
+        end
+
+        def test_class_type_falls_back_to_string_when_no_resolver_matches
+          # Regression guard: existing default behavior (no custom resolver registered)
+          # must remain identical — unknown classes resolve to plain string schema.
+          unknown = Class.new
+          schema = @resolver.build_exposure_base_schema(unknown)
+
+          assert_equal Constants::SchemaTypes::STRING, schema.type
+          assert_nil schema.format
+        end
+
+        def test_first_matching_type_resolver_wins_for_class_exposure
+          first = Class.new do
+            extend GrapeOAS::TypeResolvers::Base
+
+            def self.handles?(type)
+              type == CustomTypeMarker
+            end
+
+            def self.build_schema(_type)
+              ApiModel::Schema.new(type: Constants::SchemaTypes::STRING, format: "first-wins")
+            end
+          end
+
+          second = Class.new do
+            extend GrapeOAS::TypeResolvers::Base
+
+            def self.handles?(type)
+              type == CustomTypeMarker
+            end
+
+            def self.build_schema(_type)
+              ApiModel::Schema.new(type: Constants::SchemaTypes::STRING, format: "second-should-not-win")
+            end
+          end
+
+          with_isolated_type_resolvers do
+            GrapeOAS.type_resolvers.register(first)
+            GrapeOAS.type_resolvers.register(second, after: first)
+
+            schema = @resolver.build_exposure_base_schema(CustomTypeMarker)
+
+            assert_equal "first-wins", schema.format
+          end
+        end
+
+        private
+
+        def with_isolated_type_resolvers
+          original = GrapeOAS.type_resolvers.to_a.dup
+          yield
+        ensure
+          GrapeOAS.type_resolvers.clear
+          original.each { |r| GrapeOAS.type_resolvers.register(r) }
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

`GrapeOAS.type_resolvers` is a first-match-wins registry that converts
request parameter types into rich schemas (Dry::Types, custom UUIDs,
primitives). Entity exposures never consult it: when an exposure's
declared type is a class that is neither a `Grape::Entity` nor a known
primitive, the exposure falls back to bare `{ type: "string" }`, even
when a resolver for that class is registered.

This PR closes that gap.

### Before
```ruby
class MyApp::Types::UUID; end
GrapeOAS.type_resolvers.register(MyUUIDResolver) # {type: "string", format: "uuid"}

# Request param: already worked
params { requires :id, type: MyApp::Types::UUID } # {type: "string", format: "uuid"}

# Entity exposure: bare string fallback
class FooEntity < Grape::Entity
  expose :id, documentation: { type: MyApp::Types::UUID } # {type: "string"}
end
```

### After

Both paths produce `{type: "string", format: "uuid"}`.

## What changed

In `TypeSchemaResolver#schema_for_class_type`, after `build_schema_for_primitive`
and before `default_string_schema`, consult `GrapeOAS.type_resolvers.build_schema(type)`.

Only the `Class` branch is touched. Grape::Entity, primitives,
Array/Hash/String/Symbol paths are unchanged. Default behavior is
byte-identical when no custom resolver is registered.