### PR TITLE
Add cross-tool agent contributor guidance for grape-oas

### DIFF
--- a/.claude/commands/critique.md
+++ b/.claude/commands/critique.md
@@ -1,0 +1,26 @@
+# Critique current changes
+
+Apply the grape-oas review checklist to the working tree (or to the diff
+range / PR specified in $ARGUMENTS).
+
+Read [agents/code-review.md](../../agents/code-review.md) and execute
+the review exactly as described:
+
+1. Identify the diff. If $ARGUMENTS is empty, use `git diff main...HEAD`.
+   If $ARGUMENTS is a PR number or URL, fetch it via `gh`. If
+   $ARGUMENTS is a git ref range, use that.
+2. Read the relevant files end-to-end (not just the changed lines) so
+   the review covers context, not just the patch.
+3. Run all six checks in order: schema correctness, test coverage,
+   boundary violations, backward compatibility, CHANGELOG / PR body,
+   code quality.
+4. Report findings using the **Block / Should fix / Consider / Nit**
+   labels defined in `agents/code-review.md`. Order by severity,
+   blocking findings first. Each finding gets `file:line`, what's
+   wrong, and the fix or a concrete question.
+5. If you have nothing to say, use the exact template from the
+   "When you have nothing to say" section. Do not invent findings to
+   look thorough.
+
+Do not soften findings. Do not add encouragement. Do not score the PR.
+Do not stop at the first problem — run all six checks every time.

--- a/.claude/commands/pr-description.md
+++ b/.claude/commands/pr-description.md
@@ -1,0 +1,37 @@
+# Generate a PR description for grape-oas
+
+Generate a PR description for the current branch (or for the diff range
+specified in $ARGUMENTS) following
+[agents/pr-description.md](../../agents/pr-description.md).
+
+Steps:
+
+1. Inspect the diff. If $ARGUMENTS is empty, use `git diff main...HEAD`.
+   If $ARGUMENTS is a git ref range, use that.
+2. Identify which exporter / introspector / type-resolver paths are
+   affected and which OAS versions (2.0, 3.0, 3.1) are impacted.
+3. Write the PR body with all required sections in order: **Problem**,
+   **Fix**, **Example**, **Schema before / after**, **Backward
+   compatibility**, **Open questions** (optional).
+4. The Schema before / after section is mandatory. If the change
+   provably does not affect emitted output (a pure refactor, docs
+   change, CI tweak), say so explicitly using the template from the
+   "When the schema-before-after section can't be filled" section of
+   `agents/pr-description.md`. Do not omit the section silently.
+5. Use a minimal Grape API snippet (under ~15 lines) for the Example
+   section. Strip everything not load-bearing.
+6. Remind the user that the CHANGELOG entry lands *after* the PR is
+   opened (it includes the PR number and author handle). The format
+   is `- [#N](https://github.com/numbata/grape-oas/pull/N):
+   summary - [@handle](https://github.com/handle).` under the
+   appropriate `### Added` / `### Fixed` / `### Changed` subsection
+   of `## [Unreleased]`. Danger warns when `CHANGELOG.md` is
+   unmodified and fails when any line breaks Keep-a-Changelog
+   format.
+
+Do not include a test plan, "🤖 Generated with…" footers, or
+`Co-Authored-By: Claude` lines. Do not list every touched file. Do not
+restate the diff in prose.
+
+Output the PR body as a single Markdown block. Do not commit or push
+anything.

--- a/.claude/skills/grape-oas-critique/SKILL.md
+++ b/.claude/skills/grape-oas-critique/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: grape-oas-critique
 description: Apply the grape-oas review checklist (six axes — schema correctness, test coverage, boundary violations, backward compatibility, CHANGELOG and PR body, code quality) when reviewing a working tree, branch, or PR in the grape-oas repository. Use when the user asks for a code review, critique, or audit on grape-oas changes — including before opening a PR, before committing, and in chained workflows where the agent reviews its own work before pushing. Output uses Block / Should fix / Consider / Nit severity labels and avoids invented findings.
+allowed-tools: Read Grep Glob Bash(git diff:*) Bash(git log:*) Bash(git show:*) Bash(git status:*) Bash(gh pr view:*) Bash(gh pr diff:*)
 ---
 
 # Critique grape-oas changes

--- a/.claude/skills/grape-oas-critique/SKILL.md
+++ b/.claude/skills/grape-oas-critique/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: grape-oas-critique
+description: Apply the grape-oas review checklist (six axes — schema correctness, test coverage, boundary violations, backward compatibility, CHANGELOG and PR body, code quality) when reviewing a working tree, branch, or PR in the grape-oas repository. Use when the user asks for a code review, critique, or audit on grape-oas changes — including before opening a PR, before committing, and in chained workflows where the agent reviews its own work before pushing. Output uses Block / Should fix / Consider / Nit severity labels and avoids invented findings.
+---
+
+# Critique grape-oas changes
+
+Apply the grape-oas review checklist to the diff in scope (working
+tree, named branch, or PR). Read
+[agents/code-review.md](../../../agents/code-review.md) and execute
+exactly as described:
+
+1. Identify the diff. Default: `git diff main...HEAD`. For a PR
+   number or URL, use `gh pr view <N>` / `gh pr diff <N>`. For a
+   custom range, use that.
+2. Read the relevant files end-to-end (not just the changed lines)
+   so the review covers context, not just the patch.
+3. Run all six checks in order: schema correctness, test coverage,
+   boundary violations, backward compatibility, CHANGELOG / PR body,
+   code quality.
+4. Report findings using the **Block / Should fix / Consider / Nit**
+   labels defined in `agents/code-review.md`. Order by severity,
+   blocking findings first. Each finding gets `file:line`, what's
+   wrong, and the fix or a concrete question.
+5. If you have nothing to say, use the exact template from the
+   "When you have nothing to say" section. Do not invent findings to
+   look thorough.
+
+Do not soften findings. Do not add encouragement padding. Do not
+score the PR. Do not stop at the first problem — run all six checks
+every time.

--- a/.claude/skills/grape-oas-pr-description/SKILL.md
+++ b/.claude/skills/grape-oas-pr-description/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: grape-oas-pr-description
+description: Write a grape-oas PR description following the project's required template — Problem, Fix, Example (a minimal Grape API snippet), Schema before / after, Backward compatibility, optional Open questions. Use when the user asks for a PR body or commit-message-style summary on grape-oas changes, when running `gh pr create` for grape-oas, and in autonomous "fix the code and push a PR" workflows where the agent must produce the PR body without further user input. Output is a single Markdown block ready to paste into the PR body.
+---
+
+# Generate a grape-oas PR description
+
+Write a PR description for the diff in scope (current branch by
+default) following
+[agents/pr-description.md](../../../agents/pr-description.md).
+
+Steps:
+
+1. Inspect the diff. Default: `git diff main...HEAD`. If a different
+   range is in scope, use that.
+2. Identify which exporter / introspector / type-resolver paths are
+   affected and which OAS versions (2.0, 3.0, 3.1) are impacted.
+3. Write the PR body with all required sections in order: **Problem**,
+   **Fix**, **Example**, **Schema before / after**, **Backward
+   compatibility**, **Open questions** (optional).
+4. The Schema before / after section is mandatory. If the change
+   provably does not affect emitted output (a pure refactor, docs
+   change, CI tweak), say so explicitly using the template from the
+   "When the schema-before-after section can't be filled" section of
+   `agents/pr-description.md`. Do not omit the section silently.
+5. Use a minimal Grape API snippet (under ~15 lines) for the Example
+   section. Strip everything not load-bearing.
+6. Remind the user that the CHANGELOG entry lands *after* the PR is
+   opened (it requires the PR number). Format:
+   `- [#N](https://github.com/numbata/grape-oas/pull/N): summary -
+   [@<handle>](https://github.com/<handle>).` under the appropriate
+   `### Added` / `### Fixed` / `### Changed` subsection of
+   `## [Unreleased]`. Danger warns when `CHANGELOG.md` is
+   unmodified and fails when any line breaks Keep-a-Changelog
+   format.
+
+Do not include a test plan, "🤖 Generated with…" footers, or
+`Co-Authored-By: Claude` lines. Do not list every touched file. Do
+not restate the diff in prose.
+
+Output the PR body as a single Markdown block. Do not commit or push
+anything.

--- a/.claude/skills/grape-oas-pr-description/SKILL.md
+++ b/.claude/skills/grape-oas-pr-description/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: grape-oas-pr-description
 description: Write a grape-oas PR description following the project's required template — Problem, Fix, Example (a minimal Grape API snippet), Schema before / after, Backward compatibility, optional Open questions. Use when the user asks for a PR body or commit-message-style summary on grape-oas changes, when running `gh pr create` for grape-oas, and in autonomous "fix the code and push a PR" workflows where the agent must produce the PR body without further user input. Output is a single Markdown block ready to paste into the PR body.
+allowed-tools: Read Grep Glob Bash(git diff:*) Bash(git log:*) Bash(git status:*)
 ---
 
 # Generate a grape-oas PR description

--- a/.cursor/rules/core.mdc
+++ b/.cursor/rules/core.mdc
@@ -1,0 +1,19 @@
+---
+description: Core grape-oas contributor rules
+alwaysApply: true
+---
+
+This repository uses [AGENTS.md](mdc:AGENTS.md) as its source of truth
+for contributor rules. Follow it strictly. This rule file only adds
+Cursor-specific reminders; everything else lives in AGENTS.md and the
+[agents/](mdc:agents) docs.
+
+- Run `bundle exec rake` (test + rubocop) before opening a PR.
+- This project uses **Minitest**, not RSpec.
+- Use `bundle exec rubocop -a` for safe autocorrections; `-A` only after
+  reviewing unsafe ones.
+- Never modify CHANGELOG.md's released sections — only add to
+  `## [Unreleased]`.
+- Stage files by name; never `git add -A`.
+- For PR bodies, follow [agents/pr-description.md](mdc:agents/pr-description.md).
+- For code review, follow [agents/code-review.md](mdc:agents/code-review.md).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,19 @@
+# Copilot instructions for grape-oas
+
+Primary contributor guidance lives in [AGENTS.md](../AGENTS.md). Read it
+first.
+
+## Copilot-specific notes
+
+- When suggesting changes to `lib/`, pair them with tests under `test/`.
+- Use **Minitest**, not RSpec. No `let`, `describe`, or `context`.
+- Add a line under `## [Unreleased]` in `CHANGELOG.md` for
+  user-visible changes (as a follow-up commit after the PR is opened
+  — the project convention requires the PR number). Danger warns
+  when `CHANGELOG.md` is unmodified and fails when any line breaks
+  Keep-a-Changelog format.
+- Run `bundle exec rake` (test + rubocop) before opening a PR.
+- For PR descriptions, follow
+  [agents/pr-description.md](../agents/pr-description.md). The
+  **Schema before/after** section is required.
+- For code review, follow [agents/code-review.md](../agents/code-review.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,178 @@
+# AGENTS.md
+
+Guidance for AI coding agents working on the **grape-oas** codebase.
+Human contributors should read [README.md](README.md) and
+[CONTRIBUTING.md](CONTRIBUTING.md) first.
+
+> If you find conflicting guidance elsewhere, **AGENTS.md wins**.
+
+## What this gem is
+
+`grape-oas` generates **OpenAPI Specification** documents (OAS 2.0, 3.0, and
+3.1) from APIs built with the [Grape](https://github.com/ruby-grape/grape)
+framework. It is built around a DTO architecture that separates *introspecting*
+a Grape API from *exporting* the spec — the same internal API model can be
+rendered to any of the three OAS versions.
+
+It is **not** a fork or extension of `grape-swagger` (which only emits OAS 2.0).
+Patterns from grape-swagger are usually wrong here. Scope is spec generation
+only — no UI, no runtime request validation. Expanding scope requires an issue
+first.
+
+## Dev environment
+
+- Ruby: `>= 3.2` (see `grape-oas.gemspec` `required_ruby_version`).
+- Use `rbenv` to select Ruby. Prefix shell commands with
+  `eval "$(rbenv init - bash)" &&` if your shell isn't initialized.
+- Install: `bin/setup` (or `bundle install`).
+- Run the full test suite: `bundle exec rake test`.
+- Run one test file: `bundle exec rake test TEST=test/path/to/file_test.rb`.
+- Run one example: `bundle exec ruby -Itest test/path/to/file_test.rb -n /pattern/`.
+- Lint: `bundle exec rubocop`.
+- Autofix safe cops: `bundle exec rubocop -a` (use `-A` only when you've
+  reviewed the unsafe corrections).
+- **Pre-PR check (run before opening a PR):** `bundle exec rake` — runs
+  `test` then `rubocop`. CI runs both checks (rubocop in one job, then a
+  Ruby × Grape matrix for tests).
+
+This project uses **Minitest**, not RSpec. Do not introduce RSpec, `let`,
+`describe`, or `context` — use `Minitest::Test` subclasses with `def test_*`
+methods.
+
+## Repo layout
+
+```
+lib/grape_oas/
+  api_model/                 # DTOs: the in-memory representation of an API
+  api_model_builders/        # Build the API model from a Grape app
+  api_model_builder.rb       # Top-level builder entry point
+  introspectors/             # Extract schemas from entities / contracts
+                             # (grape-entity, dry-validation, dry-types)
+  type_resolvers/            # Map Ruby/Grape types to OAS types
+  exporter/                  # Render the API model as OAS 2.0 / 3.0 / 3.1
+  rake/                      # Rake tasks shipped to consumers
+  documentation_extension.rb # Mounts add_oas_documentation onto Grape::API
+  schema_constraints.rb      # Constraint propagation helpers
+
+test/
+  grape_oas/                # Unit tests, mirrors lib/ structure
+  integration/              # Cross-component tests
+  e2e/                      # Full Grape API → JSON spec tests
+  helpers/                  # Test-only helpers
+  support/                  # Shared fixtures and matchers
+  test_helper.rb
+
+docs/                       # Reference documentation for users
+agents/                     # Extended guidance for agents (read these)
+```
+
+## Conventions
+
+- Every `.rb` file starts with `# frozen_string_literal: true`.
+- Top-level namespace is `GrapeOAS` (not `Grape::OAS`).
+- Public API = anything reachable from `GrapeOAS.<method>`, the
+  `Grape::API`-mounted DSL (`add_oas_documentation`), plus classes
+  documented in `docs/`. Everything else is internal — refactor freely.
+- Prefer keyword arguments for new methods with several parameters
+  (RuboCop allows up to 13 positional, but new methods past ~3 are
+  hard to read at call sites). Existing positional-heavy methods like
+  `add_documentation_routes` in `documentation_extension.rb` are
+  exceptions, not patterns to copy.
+- Generated OAS structures are plain `Hash` with **string keys** (per OAS
+  spec). Do not use symbols in emitted output.
+- Omit optional keys entirely instead of emitting `nil` / `null`.
+- See [agents/conventions.md](agents/conventions.md) for file size,
+  comments, naming, and "where new code goes" rules. Read it before
+  adding new code.
+
+## Testing rules
+
+- Minitest only. New tests go under `test/`, mirroring `lib/` paths.
+- Any new public method gets a test. Any bug fix gets a regression test
+  that **fails on the parent commit and passes on this commit**.
+- E2E tests under `test/e2e/` assert on full Grape-API → OAS-JSON output
+  and are slow — prefer unit tests in `test/grape_oas/` when you can
+  isolate the behavior.
+- Reuse existing fixture Grape APIs in `test/support/` before adding new
+  ones. Duplicate fixtures bloat suite runtime.
+- Assert on structural subsets of generated JSON, not full equality,
+  unless shape-fidelity is the test's whole point.
+
+## Pull requests
+
+- When **writing** a PR description, follow
+  [agents/pr-description.md](agents/pr-description.md). The required
+  sections (in order) are: **Problem**, **Fix**, **Example** (a minimal
+  Grape API snippet), **Schema before / after**, **Backward
+  compatibility**. Do not skip the schema diff — see the doc for the
+  one allowed exception.
+- When **reviewing** a PR (your own before opening it, or someone else's),
+  follow [agents/code-review.md](agents/code-review.md). Claude users can
+  invoke this with `/critique`.
+- Add a `CHANGELOG.md` entry under `## [Unreleased]` for every
+  user-visible change. The project convention is `[#N](url): summary
+  - [@handle](url).`, which requires the PR number, so the entry
+  lands *after* the PR is opened — push it as a follow-up commit.
+  Danger warns when `CHANGELOG.md` is unmodified and fails when any
+  line breaks Keep-a-Changelog format; the PR-numbered link form is
+  one of two formats Danger accepts (the bare
+  `* Capitalized summary - [@handle](url).` would also pass) and is
+  project convention, not a Danger requirement. See
+  [agents/pr-description.md](agents/pr-description.md) for the exact
+  line format.
+- Stage files specifically by name; never `git add -A` or `git add .`.
+- Do not bump the gem version in feature PRs — version bumps happen at
+  release time.
+- Do not include test plans, agent attribution footers, or
+  "🤖 Generated with…" lines in PR bodies or commit messages.
+
+## Boundaries
+
+- Do not commit credentials, RubyGems API keys, or `~/.gem/credentials`
+  content.
+- Do not modify `.github/workflows/`, `Dangerfile`, `Rakefile`, or release
+  tasks (`namespace :release` in `Rakefile`) without explicit maintainer
+  approval.
+- Do not monkey-patch Grape classes from `lib/`. Extension points should
+  be explicit modules (introspectors, exporters, type resolvers) that the
+  user registers.
+- Do not add runtime dependencies lightly. Each new entry in
+  `grape-oas.gemspec` needs justification in the PR description.
+- The `.serena/`, `.ruby-lsp/`, `coverage/`, `pkg/`, and `tmp/`
+  directories are tool/build artifacts — do not commit changes inside
+  them.
+
+## Things an LLM will get wrong without being told
+
+- **`grape-swagger` ≠ `grape-oas`.** Many Stack Overflow answers and blog
+  posts conflate them. grape-swagger emits OAS 2.0 only and uses
+  different internals. Do not import code or patterns from grape-swagger
+  — adapt for OAS 3.x and this gem's DTO architecture instead.
+- **OAS 3.0 vs 3.1 diverge.** OAS 3.0 uses `nullable: true` by
+  default and an OpenAPI-specific JSON Schema dialect; OAS 3.1 uses
+  `type: ["string", "null"]` and aligns with JSON Schema 2020-12.
+  The exporter has separate code paths — when changing one, decide
+  explicitly whether the other needs the same change. The
+  `nullable_strategy:` option (`KEYWORD` / `TYPE_ARRAY`) is
+  configurable for OAS 3.0; OAS 3.1 hard-overrides to `TYPE_ARRAY`
+  regardless of the option (see
+  `lib/grape_oas/exporter/oas31_schema.rb`), so a `nullable: true`
+  in OAS 3.1 output is always a bug. OAS 2.0 nullable handling is
+  underspecified (issue #91) — see `agents/code-review.md`.
+- **Grape parameter DSL has non-standard syntax.** `requires :foo, type:
+  Array[Integer]` is a Grape convention, not standard Ruby generics.
+- **`$ref` and composition (`allOf` / `oneOf` / `anyOf`) drop attributes
+  by default.** When changing schema rendering, check that attributes
+  (`default`, `enum`, `format`, constraints, extensions) survive both
+  paths. PR #70 documents the full attribute-survival matrix.
+- **`bundle exec rake` is the validation gate**, not just `rake test`.
+  The default task runs tests and RuboCop together; CI runs the same
+  checks but splits them across a rubocop job and a Ruby × Grape test
+  matrix.
+
+## If you are unsure
+
+Stop and ask in the PR rather than guessing. For unclear schema impact,
+re-run the affected exporter against the e2e fixtures
+(`bundle exec rake test TEST=test/e2e/...`) and paste the diff in your
+question — that turns "I'm not sure" into a concrete review item.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [#92](https://github.com/numbata/grape-oas/pull/92): Add `AGENTS.md` and cross-tool agent contributor guidance (`agents/` docs, `/critique` and `/pr-description` slash commands, thin pointers for Cursor/Copilot/Gemini); tighten `grape-oas.gemspec` `spec.files` to ship only consumer-facing docs - [@numbata](https://github.com/numbata).
+* Your contribution here
+
 ### Fixed
 
 - [#78](https://github.com/numbata/grape-oas/pull/78): Fix: use empty schema for undocumented responses instead of `{ type: string }` - [@bogdan](https://github.com/bogdan).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [#92](https://github.com/numbata/grape-oas/pull/92): Add cross-tool AI-agent contributor guidance and tighten gem file packaging - [@numbata](https://github.com/numbata).
-* Your contribution here
+- Your contribution here
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [#92](https://github.com/numbata/grape-oas/pull/92): Add `AGENTS.md` and cross-tool agent contributor guidance (`agents/` docs, `/critique` and `/pr-description` slash commands, thin pointers for Cursor/Copilot/Gemini); tighten `grape-oas.gemspec` `spec.files` to ship only consumer-facing docs - [@numbata](https://github.com/numbata).
+- [#92](https://github.com/numbata/grape-oas/pull/92): Add cross-tool AI-agent contributor guidance and tighten gem file packaging - [@numbata](https://github.com/numbata).
 * Your contribution here
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/agents/code-review.md
+++ b/agents/code-review.md
@@ -1,0 +1,172 @@
+# Reviewing a grape-oas change
+
+Apply this when reviewing your own work before opening a PR, reviewing
+someone else's PR, or running `/critique` on a working tree.
+
+## Mindset
+
+Adversarial toward the code, not the author. Assume the diff is wrong
+until proven right. Every line earns its place. Your job is to catch
+things the author missed.
+
+Skip encouragement padding ("great refactor", "nice catch"). Skip
+sneering ("obviously", "surprised this passed CI"). State the problem
+and the fix; the harshness is in the standard, not the tone.
+
+## What to check, in order
+
+Work through all six in order before reporting; partial reviews waste
+the author's cycles. (See "What NOT to do" for why.)
+
+### 1. Schema correctness
+
+This is the highest-stakes axis in this repo. Mistakes here ship broken
+OpenAPI to every consumer of every API that uses grape-oas.
+
+- Does the emitted OAS still validate against the spec for every path
+  the diff touches? OAS 3.0 and 3.1 have different rules — check both
+  if both exporters are affected.
+- For OAS 3.0 changes: is the `nullable` representation correct for
+  the API's `nullable_strategy:`? OAS 3.0 honors the option, so both
+  `nullable: true` (`KEYWORD`) and `type: ["X", "null"]`
+  (`TYPE_ARRAY`) can be legitimate output — check the API's strategy
+  before flagging either as a bug.
+- For OAS 3.1 changes: output must always be `type: ["X", "null"]`.
+  OAS 3.1 hard-overrides `nullable_strategy` to `TYPE_ARRAY`
+  regardless of the API option (see
+  `lib/grape_oas/exporter/oas31_schema.rb`). A `nullable: true` in
+  3.1 output is a bug, full stop.
+- For OAS 2.0 changes: nullable handling is currently underspecified
+  in the codebase (no default strategy, no fallback in the
+  exporter — see issue #91). Do not block on nullable representation
+  in OAS 2.0 output unless the change clearly regresses behavior;
+  flag uncertainty for maintainer review.
+- Are keys in emitted output **strings**, never symbols?
+- Are optional keys **omitted** when their value would be nil/empty,
+  rather than emitted with a `null` value?
+- Do `$ref` and composition (`allOf` / `oneOf` / `anyOf`) paths
+  preserve the attributes the author thinks they preserve? `$ref`
+  wrappers in particular drop most attributes unless the author
+  explicitly handled them. PR #70's attribute survival matrix is the
+  reference.
+
+### 2. Test coverage of the actual change
+
+- Is there a test that **fails on the parent commit and passes on this
+  commit**? If not, the test does not prove the fix works. Ask for a
+  regression test.
+- Bug fix without a regression test → block.
+- New public method without a test → block.
+- Did the author update an existing test that asserted the buggy
+  behavior? If so, the test name and surrounding comments should
+  reflect the *new* intended behavior, not the old one.
+- Are end-to-end tests in `test/e2e/` being added when a unit test in
+  `test/grape_oas/` would suffice? E2E tests are slow — push back.
+
+### 3. Boundary violations
+
+- Does the diff monkey-patch any Grape class from `lib/`? Should be an
+  explicit extension module instead.
+- Does it touch `.github/workflows/`, `Dangerfile`, `Rakefile`, or
+  release tasks without flagging it as a process change in the PR
+  body?
+- Does it add a runtime dependency to `grape-oas.gemspec` without
+  justification in the PR body?
+- Does it add code under `lib/grape_oas/` that's clearly not part of
+  any existing namespace (`introspectors/`, `exporter/`,
+  `type_resolvers/`, `api_model/`, `api_model_builders/`)? Where does
+  it belong?
+
+### 4. Backward compatibility
+
+- Does the public API surface change? `GrapeOAS.<method>` signatures,
+  any class documented in `docs/`, anything users call directly.
+- Does the emitted OAS shape change for **inputs that don't exercise
+  the fix**? That is the silent breakage that hurts most. Look for
+  changed defaults, removed keys, reordered output.
+- If either is true, is it called out in the PR body's
+  backward-compatibility section? If not → block.
+
+### 5. CHANGELOG and PR body
+
+- Is there a new entry under `## [Unreleased]` in `CHANGELOG.md`?
+  Danger checks file modification and line format, not specifically
+  `## [Unreleased]` presence — verify visually.
+- Does the PR body have the required sections (Problem / Fix / Example
+  / Schema before-after / Backward compatibility)? See
+  [pr-description.md](pr-description.md).
+- Is the schema-before-after block actually showing the change, or is
+  it a copy-paste of identical YAML?
+
+### 6. Code quality (the easy stuff)
+
+This last because RuboCop catches most of it.
+
+- File size: any new/modified file pushing past ~400 lines? If so,
+  what would split cleanly out? See [conventions.md](conventions.md).
+- Comments: any "explains what the next line does" slop? Any "added
+  for X" / "used by Y" / "fix for issue #123" rot? Any TODO without an
+  owner or issue link? Strip them.
+- Method length: RuboCop caps methods at 60 lines, but anything past
+  30 is worth questioning unless the method is genuinely sequential
+  setup.
+- Naming: does each new identifier carry its weight? `data`, `result`,
+  `obj`, `value` are usually a sign the author didn't think hard
+  enough.
+
+## How to write the review
+
+Order findings from "this blocks the PR" to "this is a nit". Use these
+labels:
+
+- **Block:** must be fixed before merge. Schema-correctness bugs,
+  missing regression tests, broken backward compatibility without
+  callout, missing CHANGELOG entry.
+- **Should fix:** should be fixed before merge but author can push
+  back. Naming, splitting a long method, missing edge-case test.
+- **Consider:** worth thinking about, author's call. Refactoring
+  suggestions, alternative approaches, future-proofing.
+- **Nit:** style, formatting, comment phrasing. Mention once, do not
+  block.
+
+For each finding, give:
+
+1. The location (`file:line` if you can).
+2. What's wrong.
+3. The fix, or a concrete question if the fix isn't obvious.
+
+Example finding:
+
+```
+**Block** — `lib/grape_oas/exporter/oas3_schema.rb:142`
+
+`build_one_of_schema` doesn't propagate `default` to the composition
+wrapper. The fix in this PR works for `allOf` and `anyOf` but the
+`oneOf` path silently drops it. Add the same `default: schema.default
+if schema.default` line and a test in
+`test/grape_oas/exporter/oas3_schema_test.rb`.
+```
+
+## What NOT to do
+
+- Do not invent issues that aren't in the diff. If you can't point to
+  a line, the finding doesn't exist.
+- Do not score the PR (no "7/10", no letter grades). The findings list
+  is the verdict.
+- Do not include encouragement padding. No "great catch on the
+  constraint bug, by the way".
+- Do not insult the author or the prior code. Even if the prior code
+  was bad, "this was broken because…" is fine; "whoever wrote this
+  clearly didn't…" is not.
+- Do not stop at the first problem. Run all six checks every time —
+  partial reviews waste review cycles.
+
+## When you have nothing to say
+
+If the diff is genuinely good, the entire review is:
+
+> Reviewed against the grape-oas review checklist. Schema correctness,
+> test coverage, boundaries, backward compatibility, CHANGELOG, and
+> code quality all check out. No findings.
+
+Resist the urge to invent something to look thorough.

--- a/agents/conventions.md
+++ b/agents/conventions.md
@@ -1,0 +1,109 @@
+# grape-oas conventions
+
+Conventions that aren't enforced by RuboCop. Read this before adding new
+code. RuboCop is the source of truth for whitespace, string quotes, line
+length, and similar mechanical rules — this file covers everything else.
+
+## File size
+
+There is no hard cap. RuboCop's `Metrics/ClassLength` is disabled
+deliberately — some classes (`exporter/oas3_schema.rb`, the
+introspectors) are inherently large because they sit on top of a wide
+upstream surface.
+
+The soft rule: **if a file is doing more than one thing, split it.**
+`lib/grape_oas/introspectors/dry_introspector_support/` is the model —
+one file per responsibility (argument extraction, AST walking, type
+unwrapping, constraint extraction / merging / application, predicate
+handling, contract resolution, inheritance, rule indexing, type-schema
+building) instead of one giant introspector. When the introspector
+itself was getting unwieldy, the shared helpers were extracted; the
+entry point stayed small.
+
+Heuristic for a new file: if you can't write a one-sentence description
+of what it does without using the word "and", it's too big. Split before
+merging, not after.
+
+## Method length
+
+RuboCop allows up to 60 lines per method. Most methods should be much
+shorter. Anything past ~30 lines is worth asking "what subroutine is
+hiding in here?". The metrics-cop exemptions in `.rubocop.yml` for the
+dry introspectors (`Metrics/MethodLength`, `Metrics/AbcSize`,
+`Metrics/CyclomaticComplexity`, `Metrics/PerceivedComplexity`) exist
+because dry-types' AST shape forces a wide dispatch — those are
+exceptions, not patterns to copy.
+
+## Comments
+
+Default to writing **no comments**. Add one only when the *why* is
+non-obvious — a hidden upstream Grape constraint, a workaround for an
+OAS spec quirk, a non-obvious invariant.
+
+Do not comment:
+
+- What the code does (well-named identifiers cover that).
+- The current task or fix (`# added for the entity-array fix` —
+  belongs in the PR description, rots in code).
+- Who calls this method (`# called from OAS3::Schema#build` — call
+  sites move).
+- Removed code (no `# removed: foo_bar()` placeholders).
+- TODOs without an owner or linked issue.
+
+Rule of thumb: if the comment would still be true a year from now,
+keep it; if it describes this week's state, delete it.
+
+## Naming
+
+- Classes named after the thing they represent in the OAS spec when
+  applicable: `Operation`, `Response`, `Parameter`, `Schema`. Don't
+  invent internal names that diverge from the spec vocabulary.
+- Internal helpers go under a `*_support/` directory next to the
+  consumer (see the `dry_introspector_support/` pattern).
+- Avoid `data`, `result`, `obj`, `value`, `info`, `metadata` as
+  variable names unless the scope is genuinely about a generic blob.
+  Specificity helps readers.
+- Predicate methods end in `?`. Bang methods only for genuine in-place
+  mutation or for "this can raise" variants.
+
+## Where new code goes
+
+| Adding… | Goes under |
+|---|---|
+| A new way to read schemas off a Ruby type (e.g., a new ORM) | `lib/grape_oas/introspectors/` |
+| A new OAS output format / version | `lib/grape_oas/exporter/` |
+| A type → OAS-type mapping | `lib/grape_oas/type_resolvers/` |
+| A new field on the in-memory model | `lib/grape_oas/api_model/` |
+| Logic that builds the model from a Grape app | `lib/grape_oas/api_model_builders/` |
+| A user-facing Rake task | `lib/grape_oas/rake/` |
+| A test fixture Grape API | `test/support/` (reuse before adding) |
+
+If your change doesn't fit any of these slots, pause. Either the slot is
+missing (open an issue first), or the change belongs somewhere else.
+
+## Public vs internal
+
+Public surface = anything reachable from `GrapeOAS.<method>`, the
+`Grape::API`-mounted DSL (`add_oas_documentation`), plus classes
+documented in `docs/`. That is what semver protects.
+
+Everything else is internal — refactor freely. If you're not sure
+whether a class is part of the public surface, grep `docs/` for its
+name; if it appears, treat it as public.
+
+## Frozen string literals
+
+Every `.rb` file starts with `# frozen_string_literal: true`. RuboCop
+enforces this — but if you're creating a new file, set it from the start
+rather than waiting for the linter to flag it.
+
+## Generated output rules
+
+Recap of the rules that affect every emitter:
+
+- Keys are strings (per OAS spec), never symbols.
+- Optional keys are *omitted* when empty, not emitted as `null`.
+- Order matters for human-readable diffs but not for the spec — prefer
+  insertion order that mirrors the OAS spec section order.
+- Do not emit OAS extension keys (`x-*`) unless the user opted in via
+  the documentation extension.

--- a/agents/pr-description.md
+++ b/agents/pr-description.md
@@ -242,6 +242,11 @@ is opened. Order of operations:
      user-readable summary - [@handle](https://github.com/handle).
    ```
 
+   Keep the summary tight — one phrase describing the user-visible
+   change, not the implementation. Aim for under ~120 characters of
+   summary text. Skim recent entries in `CHANGELOG.md` for examples
+   of the right length.
+
 2. Push the CHANGELOG commit to the PR branch. Danger
    (`changelog.check!`) does two things: it warns when
    `CHANGELOG.md` is unmodified and fails when any line breaks

--- a/agents/pr-description.md
+++ b/agents/pr-description.md
@@ -1,0 +1,263 @@
+# Writing a PR description for grape-oas
+
+Opinionated guide to writing a grape-oas PR description.
+
+## Why these rules exist
+
+grape-oas's whole job is to emit a specific OpenAPI Specification
+document shape. Most reviews boil down to one question: **did the
+emitted JSON/YAML change in the way the author intended, and did
+anything else change by accident?** A PR description that doesn't show
+the schema diff forces the reviewer to reconstruct it from the test
+files, which is slow and error-prone. The required sections below are
+all optimized for that question.
+
+## Required structure
+
+Going forward, grape-oas PR bodies should contain these sections, in
+this order. Existing merged PRs predate this template — do not cite
+them as proof a section is optional. The embedded worked example
+below is the template's reference shape. Skip a section only if it
+genuinely doesn't apply (most of the time, none of them should be
+skipped).
+
+````markdown
+## Problem
+
+One paragraph. What was wrong, missing, or slow before this PR? Lead with
+*why*. If this fixes an issue, link it ("Closes #123").
+
+## Fix
+
+One to three paragraphs. What does this PR change to address the problem?
+Describe the approach, not the line-by-line diff. The reviewer can read
+the diff; they cannot read your mind about why you chose this approach
+over alternatives you considered.
+
+## Example
+
+A minimal Grape API snippet that triggers the changed behavior. Keep it
+under ~15 lines — strip everything not load-bearing for the example.
+
+```ruby
+class API < Grape::API
+  # the smallest API that demonstrates the change
+end
+```
+
+## Schema before / after
+
+Show the OAS output for the example above, before and after this PR. Use
+`yaml` or `json` fenced blocks. Diff comments (`# Before` / `# After`)
+are encouraged. If you changed multiple call sites, show one example per
+site, not all of them.
+
+```yaml
+# Before
+properties:
+  role:
+    $ref: "#/components/schemas/UserEntity"
+
+# After — in OAS 3.0 a $ref cannot have sibling keywords, so allOf
+# is the canonical workaround for attaching attributes (default,
+# enum, constraints). OAS 3.1 allows $ref siblings, but the exporter
+# still emits the allOf wrap for output consistency across versions.
+properties:
+  role:
+    allOf:
+      - $ref: "#/components/schemas/UserEntity"
+    default: "guest"
+```
+
+## Backward compatibility
+
+One sentence per category:
+- Public API surface: changed / unchanged?
+- Emitted OAS shape for inputs that don't exercise this fix: changed /
+  unchanged?
+- New runtime/dev dependencies: yes (justify) / no?
+
+If everything is unchanged, write "No public API or emitted-shape changes
+for inputs not exercising this fix."
+
+## Open questions (optional)
+
+Things you want the reviewer's opinion on. Naming, scope of the change,
+"is this the right place to put this?" Flag explicitly so the reviewer
+engages with them rather than rubber-stamping.
+````
+
+## What you do *not* include
+
+- **Test plan / "How I tested this".** The diff in `test/` and CI
+  already cover what was tested; restating it is noise. A short
+  *coverage* note is fine when the test diff alone doesn't make the
+  scope obvious (e.g. "covers cold + warm-cache paths" for a
+  caching change). The line is: don't restate, do flag what's
+  non-obvious.
+- **Agent attribution footers** like `🤖 Generated with [Claude Code]`
+  or `Co-Authored-By: Claude`. These belong nowhere in this repo.
+- **Bullet lists of every file you touched.** The diff already shows
+  that.
+- **Restating the diff in prose.** "I added a method called `foo` that
+  does X" wastes reviewer attention if the diff is right there.
+
+## When the schema-before-after section can't be filled
+
+If the change provably does not affect emitted output (a pure refactor,
+a documentation change, a CI tweak), say so explicitly in place of the
+schema diff. "Provably" means: re-run the e2e fixtures
+(`bundle exec rake test TEST=test/e2e/...`) before and after the
+change and confirm byte-identical output.
+
+```markdown
+## Schema before / after
+
+No change to emitted output. This PR refactors `<file>`; coverage is in
+`test/grape_oas/<file>_test.rb`, which produces identical fixtures
+before and after.
+```
+
+Don't omit the section silently — the reviewer needs to know you
+considered it.
+
+## Worked example (small bug fix)
+
+A complete PR body constructed around the PR #78 fix to demonstrate
+every required section. The actual PR #78 body uses a subset
+(Problem / Fix / Test change); the version below is the
+template-conforming form of the same change.
+
+````markdown
+## Problem
+
+When a route has no entity and no documented response, grape-oas emits
+`schema: { type: string }` for the response body. This is incorrect — it
+tells API consumers the endpoint returns a plain string, when in
+reality the response shape is simply unknown.
+
+## Fix
+
+An undocumented response should produce an empty schema (`{}`), which
+is the correct OAS representation for "any value / shape unknown".
+The OAS3 response builder now defaults to `{}` when no schema source
+(entity, documented response, params) is available, instead of falling
+through to the primitive resolver's default.
+
+## Example
+
+```ruby
+class API < Grape::API
+  format :json
+
+  resource :ping do
+    desc "Health check"
+    get { { status: "ok" } }
+  end
+end
+```
+
+## Schema before / after
+
+```yaml
+# Before — incorrectly claims the response is a string
+paths:
+  /ping:
+    get:
+      responses:
+        '200':
+          description: Health check
+          content:
+            application/json:
+              schema:
+                type: string
+
+# After — empty schema correctly means "any value / shape unknown"
+paths:
+  /ping:
+    get:
+      responses:
+        '200':
+          description: Health check
+          content:
+            application/json:
+              schema: {}
+```
+
+## Backward compatibility
+
+- Public API surface: unchanged.
+- Emitted OAS shape for inputs that don't exercise this fix: unchanged
+  — only routes with no entity and no documented response are affected.
+- New runtime/dev dependencies: none.
+````
+
+## Patterns for larger PRs
+
+When a single PR changes behavior across several rendering paths or
+introduces a measured perf improvement, the template grows in two
+predictable ways. Both predate this template, but the patterns are
+worth lifting:
+
+- **Multiple `## Example` blocks**, one per affected rendering path
+  (e.g. `$ref` wrapper, `allOf`, `oneOf`). PR #70 ("Propagate schema
+  attributes through `$ref` and composition paths") is a good example.
+- **Attribute or behavior survival matrix** — a small table summarizing
+  the new behavior across paths. Earns its space when the diff touches
+  many independent call sites; PR #70 ships one.
+- **Measured-impact table** for performance work, with before/after
+  numbers and the profiling output that motivated the change. PR #64
+  ("perf: memoize default_format and content_types resolution per
+  generation") is the reference here.
+
+Note: PR #70 and PR #64 predate the template entirely. They use
+`## Summary` instead of `## Problem`, lack most of the required
+sections, and PR #64 has a `## Tests` section that this template
+discourages. Lift the listed patterns; do not lift the section names
+or overall structure.
+
+## Workflow around opening the PR
+
+The project convention for CHANGELOG entries includes the PR number
+and author handle, so the entry can only be written *after* the PR
+is opened. Order of operations:
+
+**Before opening the PR**
+
+1. Run `bundle exec rake` (test + rubocop) locally. CI runs the same
+   checks but splits them across a rubocop job and a Ruby × Grape
+   test matrix.
+2. Confirm the schema-before-after block in the PR body matches the
+   actual diff in `test/`. If they disagree, the test wins; update
+   the PR body.
+
+**After opening the PR (and getting its number)**
+
+1. Add a line under the appropriate subsection of `## [Unreleased]` in
+   `CHANGELOG.md` (`### Added`, `### Fixed`, or `### Changed`). The
+   format used throughout this project is:
+
+   ```
+   - [#N](https://github.com/numbata/grape-oas/pull/N): One-line
+     user-readable summary - [@handle](https://github.com/handle).
+   ```
+
+2. Push the CHANGELOG commit to the PR branch. Danger
+   (`changelog.check!`) does two things: it warns when
+   `CHANGELOG.md` is unmodified and fails when any line breaks
+   Keep-a-Changelog format. The PR-numbered link form is one of two
+   formats Danger accepts; this project conventionally uses it for
+   traceability, but `* Capitalized summary - [@handle](url).` (no
+   PR link) would also pass. The CHANGELOG entry lives in the file,
+   not in the PR body.
+
+## Commit messages
+
+Same rules apply, scaled down:
+
+- Imperative present tense ("Propagate schema attributes…", not
+  "Propagated" or "Propagates").
+- First line under 72 characters.
+- Body explains *why* and links the issue if relevant.
+- No agent attribution footers.
+- One logical change per commit. One logical change per PR.

--- a/grape-oas.gemspec
+++ b/grape-oas.gemspec
@@ -24,7 +24,8 @@ Gem::Specification.new do |spec|
     "rubygems_mfa_required" => "true"
   }
 
-  spec.files = Dir["lib/**/*"] + %w[README.md CHANGELOG.md LICENSE.txt grape-oas.gemspec]
+  spec.files = Dir["lib/**/*"].reject { |path| File.directory?(path) } +
+               %w[README.md CHANGELOG.md LICENSE.txt grape-oas.gemspec]
 
   spec.add_dependency "grape", ">= 3.0"
   spec.add_dependency "zeitwerk"

--- a/grape-oas.gemspec
+++ b/grape-oas.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
     "rubygems_mfa_required" => "true"
   }
 
-  spec.files = Dir["lib/**/*", "*.md", "LICENSE.txt", "grape-oas.gemspec"]
+  spec.files = Dir["lib/**/*"] + %w[README.md CHANGELOG.md LICENSE.txt grape-oas.gemspec]
 
   spec.add_dependency "grape", ">= 3.0"
   spec.add_dependency "zeitwerk"


### PR DESCRIPTION
## Problem

grape-oas had no guidance for AI coding agents. Contributors using
Claude Code, Codex, Cursor, Copilot, opencode, or Gemini CLI hit the
repo cold and either fabricated conventions (RSpec instead of
Minitest, `Grape::OAS` instead of `GrapeOAS`, grape-swagger patterns
instead of OAS 3.x ones) or produced PRs that the maintainer had to
hand-correct on style basics that should have been encoded once.

## Fix

Add a single source of truth (`AGENTS.md`) at the repo root with
thin per-tool pointers (`CLAUDE.md` / `GEMINI.md` symlinks,
`.cursor/rules/core.mdc`, `.github/copilot-instructions.md`) and
extended guidance under `agents/`:

- `agents/pr-description.md` — required PR body shape with a worked
  example.
- `agents/code-review.md` — six-axis review checklist (schema
  correctness, test coverage, boundary violations, backward
  compatibility, CHANGELOG and PR body, code quality) with explicit
  Block / Should fix / Consider / Nit severity labels.
- `agents/conventions.md` — file size, no-comments-unless-the-why-is-
  non-obvious rule, naming, where new code goes.

Two repo-scoped slash commands wrap the `agents/` docs so Claude
users can type `/critique` or `/pr-description`. Force-added past
the global `.claude/` ignore so they ship with the repo.

`AGENTS.md` includes a "Things an LLM will get wrong without being
told" section that calls out the grape-swagger / grape-oas
conflation, OAS 3.0 / 3.1 nullable divergence, the `$ref` /
composition attribute-drop trap, and `bundle exec rake` as the
validation gate.

Also tightens `grape-oas.gemspec` `spec.files` to an explicit
allowlist so the new agent docs (and `CONTRIBUTING.md` /
`RELEASING.md`) don't ship to RubyGems consumers.

## Example

This PR adds documentation, slash commands, and packaging — no
executable surface. The closest analog to a "Grape API snippet" is
the AGENTS.md repo-layout block that agents read on every task:

```
lib/grape_oas/
  api_model/                 # DTOs: in-memory representation of an API
  api_model_builders/        # Build the API model from a Grape app
  introspectors/             # Extract schemas from entities / contracts
                             # (grape-entity, dry-validation, dry-types)
  type_resolvers/            # Map Ruby/Grape types to OAS types
  exporter/                  # Render the API model as OAS 2.0 / 3.0 / 3.1
  ...
```

## Schema before / after

No change to emitted OAS output. This PR ships docs and tightens
gem packaging only; full test suite produces identical fixtures
before and after.

The gem tarball *does* change shape — five `.md` files at root no
longer ship to RubyGems consumers. Verified by
`bundle exec rake build` followed by tarball inspection:

```
# Before — root .md files in published gem
AGENTS.md          # NEW in this PR
CHANGELOG.md
CLAUDE.md          # NEW symlink in this PR
CONTRIBUTING.md
GEMINI.md          # NEW symlink in this PR
README.md
RELEASING.md

# After — explicit allowlist
CHANGELOG.md
LICENSE.txt
README.md
grape-oas.gemspec
```

## Backward compatibility

- Public API surface: unchanged.
- Emitted OAS shape for any input: unchanged.
- New runtime/dev dependencies: none.
- Gem tarball contents: 5 root `.md` files removed
  (`CONTRIBUTING.md`, `RELEASING.md`, plus the 3 newly-introduced
  agent docs). None of them are referenced by gem code at runtime,
  so consumers see no functional change — only a smaller install
  footprint.

## Open questions

- Worth filtering `agents/` and `.cursor/` out of the GitHub release
  tarball as well? Currently nothing prevents them from going in
  there, but unlike the RubyGems package nobody installs from that
  source path-by-path.
- Issue #91 (OAS 2.0 nullable handling has no default strategy) was
  surfaced while writing the agent docs and is referenced from
  `AGENTS.md` and `agents/code-review.md`. Out of scope for this PR
  but worth knowing about.