### PR TITLE
Unify type resolution for entity exposures through the resolver chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Entity exposures now consult `GrapeOAS.type_resolvers` before falling back to `{ type: "string" }`, matching the behavior already used for request parameters - [@numbata](https://github.com/numbata).
+- [#95](https://github.com/numbata/grape-oas/pull/95): Entity exposures now consult `GrapeOAS.type_resolvers` before falling back to `{ type: "string" }`, matching the behavior already used for request parameters - [@numbata](https://github.com/numbata).
 * Your contribution here
 
 ## [1.4.0] - 2026-04-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- [#95](https://github.com/numbata/grape-oas/pull/95): Entity exposures now consult `GrapeOAS.type_resolvers` before falling back to `{ type: "string" }`, matching the behavior already used for request parameters - [@numbata](https://github.com/numbata).
+- [#95](https://github.com/numbata/grape-oas/pull/95): Entity exposures now consult `GrapeOAS.type_resolvers` - [@numbata](https://github.com/numbata).
 * Your contribution here
 
 ## [1.4.0] - 2026-04-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Entity exposures now consult `GrapeOAS.type_resolvers` before falling back to `{ type: "string" }`, matching the behavior already used for request parameters. Custom resolvers registered in the chain apply to both paths.
-* `TypeResolvers::Registry#build_schema` now guarantees a non-nil return by falling back to `DefaultResolver` when no registered resolver matches.
-* `TypeResolvers::PrimitiveResolver#build_schema` returns `nil` for unknown types instead of silently defaulting to string schema.
-
-### Deprecated
-
-* `TypeResolvers::Registry#handles?` — use `#registered_resolver_for?` instead.
+- Entity exposures now consult `GrapeOAS.type_resolvers` before falling back to `{ type: "string" }`, matching the behavior already used for request parameters - [@numbata](https://github.com/numbata).
 * Your contribution here
 
 ## [1.4.0] - 2026-04-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Entity exposures now consult `GrapeOAS.type_resolvers` before falling back to `{ type: "string" }`, matching the behavior already used for request parameters. Custom resolvers registered in the chain apply to both paths.
+* `TypeResolvers::Registry#build_schema` now guarantees a non-nil return by falling back to `DefaultResolver` when no registered resolver matches.
+* `TypeResolvers::PrimitiveResolver#build_schema` returns `nil` for unknown types instead of silently defaulting to string schema.
+
+### Deprecated
+
+* `TypeResolvers::Registry#handles?` — use `#registered_resolver_for?` instead.
 * Your contribution here
 
 ## [1.4.0] - 2026-04-23

--- a/lib/grape_oas.rb
+++ b/lib/grape_oas.rb
@@ -148,7 +148,7 @@ module GrapeOAS
       registry.register(TypeResolvers::ArrayResolver)
       # DryTypeResolver handles Dry::Types (standalone, not arrays)
       registry.register(TypeResolvers::DryTypeResolver)
-      # PrimitiveResolver is the fallback for basic types
+      # PrimitiveResolver handles known Ruby primitives
       registry.register(TypeResolvers::PrimitiveResolver)
       registry
     end

--- a/lib/grape_oas/api_model_builders/path.rb
+++ b/lib/grape_oas/api_model_builders/path.rb
@@ -12,7 +12,7 @@ module GrapeOAS
 
       # Matches Grape's wildcard segments: /?*param or /*param
       # The optional ? before * is Grape's syntax for an optional leading slash
-      WILDCARD_PARAMETER_PATTERN = /\??\*(?<param>[^\/()]+)/
+      WILDCARD_PARAMETER_PATTERN = %r{\??\*(?<param>[^/()]+)}
       private_constant :WILDCARD_PARAMETER_PATTERN
 
       NORMALIZED_PLACEHOLDER = /\{[^}]+\}/

--- a/lib/grape_oas/introspectors/entity_introspector_support/type_schema_resolver.rb
+++ b/lib/grape_oas/introspectors/entity_introspector_support/type_schema_resolver.rb
@@ -22,8 +22,7 @@ module GrapeOAS
         # @return [ApiModel::Schema]
         def build_exposure_base_schema(type)
           if type.is_a?(Array)
-            # Array instance like [String] - extract inner type
-            inner = schema_for_type(type.first)
+            inner = type.first ? schema_for_type(type.first) : ApiModel::Schema.new(type: Constants::SchemaTypes::STRING)
             ApiModel::Schema.new(type: Constants::SchemaTypes::ARRAY, items: inner)
           elsif type == Array
             # Array class itself - create array with string items
@@ -34,7 +33,7 @@ module GrapeOAS
           elsif type.is_a?(Hash) || type == Hash
             ApiModel::Schema.new(type: Constants::SchemaTypes::OBJECT)
           else
-            schema_for_type(type) || ApiModel::Schema.new(type: Constants::SchemaTypes::STRING)
+            schema_for_type(type)
           end
         end
 
@@ -87,7 +86,7 @@ module GrapeOAS
           when String, Symbol
             schema_for_string_type(type.to_s)
           else
-            default_string_schema
+            GrapeOAS.type_resolvers.build_schema(type)
           end
         end
 
@@ -95,7 +94,7 @@ module GrapeOAS
           if defined?(Grape::Entity) && type <= Grape::Entity
             GrapeOAS.introspectors.build_schema(type, stack: @stack, registry: @registry)
           else
-            build_schema_for_primitive(type) || default_string_schema
+            GrapeOAS.type_resolvers.build_schema(type)
           end
         end
 
@@ -104,13 +103,8 @@ module GrapeOAS
           if entity_class
             GrapeOAS.introspectors.build_schema(entity_class, stack: @stack, registry: @registry)
           else
-            schema_type = Constants.primitive_type(type_name) || Constants::SchemaTypes::STRING
-            ApiModel::Schema.new(type: schema_type)
+            GrapeOAS.type_resolvers.build_schema(type_name)
           end
-        end
-
-        def default_string_schema
-          ApiModel::Schema.new(type: Constants::SchemaTypes::STRING)
         end
 
         def resolve_entity_from_string(type_name)
@@ -122,16 +116,6 @@ module GrapeOAS
           klass if klass.is_a?(Class) && klass <= Grape::Entity
         rescue NameError
           nil
-        end
-
-        def build_schema_for_primitive(type)
-          schema_type = Constants.primitive_type(type)
-          return nil unless schema_type
-
-          ApiModel::Schema.new(
-            type: schema_type,
-            format: Constants.format_for_type(type),
-          )
         end
       end
     end

--- a/lib/grape_oas/introspectors/entity_introspector_support/type_schema_resolver.rb
+++ b/lib/grape_oas/introspectors/entity_introspector_support/type_schema_resolver.rb
@@ -22,7 +22,7 @@ module GrapeOAS
         # @return [ApiModel::Schema]
         def build_exposure_base_schema(type)
           if type.is_a?(Array)
-            inner = type.first ? schema_for_type(type.first) : ApiModel::Schema.new(type: Constants::SchemaTypes::STRING)
+            inner = schema_for_type(type.first)
             ApiModel::Schema.new(type: Constants::SchemaTypes::ARRAY, items: inner)
           elsif type == Array
             # Array class itself - create array with string items

--- a/lib/grape_oas/type_resolvers/base.rb
+++ b/lib/grape_oas/type_resolvers/base.rb
@@ -47,6 +47,9 @@ module GrapeOAS
     #
     module Base
       # Checks if this resolver can handle the given type.
+      # A true return does not guarantee build_schema will return non-nil —
+      # the registry treats a nil build_schema as "pass" and tries the next
+      # resolver in the chain.
       #
       # @param type [String, Class, Object] The type to check (stringified or actual)
       # @return [Boolean] true if this resolver can handle the type
@@ -55,9 +58,11 @@ module GrapeOAS
       end
 
       # Builds an OpenAPI schema from the given type.
+      # Returns nil if this resolver cannot produce a schema, allowing
+      # the registry to fall back to the next resolver or DefaultResolver.
       #
       # @param type [String, Class, Object] The type to build schema for
-      # @return [ApiModel::Schema] The built schema
+      # @return [ApiModel::Schema, nil] The built schema, or nil
       def build_schema(type)
         raise NotImplementedError, "#{self} must implement .build_schema(type)"
       end

--- a/lib/grape_oas/type_resolvers/base.rb
+++ b/lib/grape_oas/type_resolvers/base.rb
@@ -55,7 +55,6 @@ module GrapeOAS
       end
 
       # Builds an OpenAPI schema from the given type.
-      # Return nil to pass to the next resolver in the chain.
       #
       # @param type [String, Class, Object] The type to build schema for
       # @return [ApiModel::Schema, nil]

--- a/lib/grape_oas/type_resolvers/base.rb
+++ b/lib/grape_oas/type_resolvers/base.rb
@@ -46,24 +46,19 @@ module GrapeOAS
     #   GrapeOAS.type_resolvers.register(MyCustomTypeResolver)
     #
     module Base
-      # Quick check used by the registry to short-circuit resolvers that
-      # clearly don't apply. The registry also checks the build_schema
-      # return value, so a nil from build_schema is treated as "pass"
-      # even if handles? returned true.
+      # Checks if this resolver can handle the given type.
       #
       # @param type [String, Class, Object] The type to check (stringified or actual)
-      # @return [Boolean] true if this resolver may be able to handle the type
+      # @return [Boolean]
       def handles?(type)
         raise NotImplementedError, "#{self} must implement .handles?(type)"
       end
 
       # Builds an OpenAPI schema from the given type.
-      # Return nil to signal that this resolver cannot produce a schema;
-      # the registry will try the next resolver and ultimately fall back
-      # to DefaultResolver.
+      # Return nil to pass to the next resolver in the chain.
       #
       # @param type [String, Class, Object] The type to build schema for
-      # @return [ApiModel::Schema, nil] The built schema, or nil to pass
+      # @return [ApiModel::Schema, nil]
       def build_schema(type)
         raise NotImplementedError, "#{self} must implement .build_schema(type)"
       end

--- a/lib/grape_oas/type_resolvers/base.rb
+++ b/lib/grape_oas/type_resolvers/base.rb
@@ -46,23 +46,24 @@ module GrapeOAS
     #   GrapeOAS.type_resolvers.register(MyCustomTypeResolver)
     #
     module Base
-      # Checks if this resolver can handle the given type.
-      # A true return does not guarantee build_schema will return non-nil —
-      # the registry treats a nil build_schema as "pass" and tries the next
-      # resolver in the chain.
+      # Quick check used by the registry to short-circuit resolvers that
+      # clearly don't apply. The registry also checks the build_schema
+      # return value, so a nil from build_schema is treated as "pass"
+      # even if handles? returned true.
       #
       # @param type [String, Class, Object] The type to check (stringified or actual)
-      # @return [Boolean] true if this resolver can handle the type
+      # @return [Boolean] true if this resolver may be able to handle the type
       def handles?(type)
         raise NotImplementedError, "#{self} must implement .handles?(type)"
       end
 
       # Builds an OpenAPI schema from the given type.
-      # Returns nil if this resolver cannot produce a schema, allowing
-      # the registry to fall back to the next resolver or DefaultResolver.
+      # Return nil to signal that this resolver cannot produce a schema;
+      # the registry will try the next resolver and ultimately fall back
+      # to DefaultResolver.
       #
       # @param type [String, Class, Object] The type to build schema for
-      # @return [ApiModel::Schema, nil] The built schema, or nil
+      # @return [ApiModel::Schema, nil] The built schema, or nil to pass
       def build_schema(type)
         raise NotImplementedError, "#{self} must implement .build_schema(type)"
       end

--- a/lib/grape_oas/type_resolvers/default_resolver.rb
+++ b/lib/grape_oas/type_resolvers/default_resolver.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module GrapeOAS
+  module TypeResolvers
+    # Catch-all used by Registry#build_schema when no registered resolver
+    # matches. Returns a plain string schema for any type. Not registered
+    # in the chain — called automatically by the registry as a built-in
+    # fallback.
+    class DefaultResolver
+      extend Base
+
+      class << self
+        def handles?(_type)
+          true
+        end
+
+        def build_schema(type)
+          logger = GrapeOAS.logger
+          if logger.respond_to?(:debug)
+            logger.debug { "No type resolver matched #{type.inspect}, falling back to string schema" }
+          end
+          ApiModel::Schema.new(type: Constants::SchemaTypes::STRING)
+        end
+      end
+    end
+  end
+end

--- a/lib/grape_oas/type_resolvers/default_resolver.rb
+++ b/lib/grape_oas/type_resolvers/default_resolver.rb
@@ -14,9 +14,7 @@ module GrapeOAS
 
         def build_schema(type)
           logger = GrapeOAS.logger
-          if logger.respond_to?(:debug)
-            logger.debug { "No type resolver matched #{type.inspect}, falling back to string schema" }
-          end
+          logger.debug { "No type resolver matched #{type.inspect}, falling back to string schema" } if logger.respond_to?(:debug)
           ApiModel::Schema.new(type: Constants::SchemaTypes::STRING)
         end
       end

--- a/lib/grape_oas/type_resolvers/default_resolver.rb
+++ b/lib/grape_oas/type_resolvers/default_resolver.rb
@@ -7,8 +7,6 @@ module GrapeOAS
     # in the chain — called automatically by the registry as a built-in
     # fallback.
     class DefaultResolver
-      extend Base
-
       class << self
         def handles?(_type)
           true

--- a/lib/grape_oas/type_resolvers/primitive_resolver.rb
+++ b/lib/grape_oas/type_resolvers/primitive_resolver.rb
@@ -4,8 +4,9 @@ module GrapeOAS
   module TypeResolvers
     # Resolves primitive types like "Integer", "String", "Boolean", "Float".
     #
-    # This is the fallback resolver that handles basic Ruby types and their
-    # string representations. It's registered last in the resolver chain.
+    # Handles basic Ruby types and their string representations, including
+    # OpenAPI type name aliases via Constants. Registered before the
+    # catch-all DefaultResolver in the resolver chain.
     #
     class PrimitiveResolver
       extend Base
@@ -33,33 +34,34 @@ module GrapeOAS
 
       class << self
         def handles?(type)
-          type_str = normalize_type(type)
-          PRIMITIVES.key?(type_str) || resolvable_to_primitive?(type)
+          !find_mapping(type).nil?
         end
 
         def build_schema(type)
-          type_str = normalize_type(type)
+          schema_type, format = find_mapping(type)
+          return nil unless schema_type
 
-          # Check direct mapping first
-          if PRIMITIVES.key?(type_str)
-            mapping = PRIMITIVES[type_str]
-            return ApiModel::Schema.new(
-              type: mapping[:type],
-              format: mapping[:format],
-            )
-          end
-
-          # Try to resolve and build schema
-          resolved = resolve_class(type_str)
-          if resolved
-            build_from_resolved(resolved)
-          else
-            # Default fallback
-            ApiModel::Schema.new(type: Constants::SchemaTypes::STRING)
-          end
+          ApiModel::Schema.new(type: schema_type, format: format)
         end
 
         private
+
+        # Single lookup used by both handles? and build_schema.
+        # Returns [type, format] or nil.
+        def find_mapping(type)
+          type_str = normalize_type(type)
+
+          if (mapping = PRIMITIVES[type_str])
+            return [mapping[:type], mapping[:format]]
+          end
+
+          # OpenAPI type name aliases ("object", "number", "boolean")
+          schema_type = Constants.primitive_type(type_str)
+          return [schema_type, Constants.format_for_type(type_str)] if schema_type
+
+          mapping = resolved_primitive_mapping(resolve_class(type_str))
+          [mapping[:type], mapping[:format]] if mapping
+        end
 
         def normalize_type(type)
           case type
@@ -72,32 +74,14 @@ module GrapeOAS
           end
         end
 
-        def resolvable_to_primitive?(type)
-          resolved = resolve_class(normalize_type(type))
-          return false unless resolved
+        def resolved_primitive_mapping(resolved)
+          return nil unless resolved
+          return nil if resolved.respond_to?(:primitive) # Dry::Types handled by DryTypeResolver
 
-          # Dry::Types should be handled by DryTypeResolver.
-          return false if resolved.respond_to?(:primitive)
+          resolved_name = resolved.respond_to?(:name) ? resolved.name : nil
+          return nil if resolved_name.nil? || resolved_name.empty?
 
-          resolved_name = resolved.respond_to?(:name) ? resolved.name : resolved.to_s
-          return false if resolved_name.nil? || resolved_name.empty?
-
-          PRIMITIVES.key?(resolved_name)
-        end
-
-        def build_from_resolved(klass)
-          # Find mapping by class name
-          type_str = klass.name
-          mapping = PRIMITIVES[type_str]
-
-          if mapping
-            ApiModel::Schema.new(
-              type: mapping[:type],
-              format: mapping[:format],
-            )
-          else
-            ApiModel::Schema.new(type: Constants::SchemaTypes::STRING)
-          end
+          PRIMITIVES[resolved_name]
         end
       end
     end

--- a/lib/grape_oas/type_resolvers/primitive_resolver.rb
+++ b/lib/grape_oas/type_resolvers/primitive_resolver.rb
@@ -46,7 +46,6 @@ module GrapeOAS
 
         private
 
-        # Single lookup used by both handles? and build_schema.
         # Returns [type, format] or nil.
         def find_mapping(type)
           type_str = normalize_type(type)

--- a/lib/grape_oas/type_resolvers/registry.rb
+++ b/lib/grape_oas/type_resolvers/registry.rb
@@ -50,31 +50,37 @@ module GrapeOAS
         self
       end
 
-      # Finds the first resolver that can handle the given type.
-      #
-      # @param type [String, Class, Object] The type to resolve
-      # @return [Class, nil] The resolver class, or nil if none found
-      def find(type)
-        @resolvers.find { |resolver| resolver.handles?(type) }
-      end
-
-      # Builds a schema using the appropriate resolver.
+      # Builds a schema using the first resolver that returns non-nil.
+      # Falls back to DefaultResolver when no registered resolver produces
+      # a schema, guaranteeing a non-nil return.
       #
       # @param type [String, Class, Object] The type to build schema for
-      # @return [ApiModel::Schema, nil] The built schema, or nil if no handler found
+      # @return [ApiModel::Schema] The built schema
       def build_schema(type)
-        resolver = find(type)
-        return nil unless resolver
+        @resolvers.each do |resolver|
+          next unless resolver.handles?(type)
 
-        resolver.build_schema(type)
+          schema = resolver.build_schema(type)
+          return schema if schema
+        end
+
+        DefaultResolver.build_schema(type)
       end
 
-      # Checks if any resolver can handle the given type.
+      # Checks if any registered resolver produces a schema for this type.
+      # Does not account for the built-in DefaultResolver fallback, so
+      # returning false does not mean build_schema will return nil — it
+      # will still produce a string schema via DefaultResolver.
       #
       # @param type [String, Class, Object] The type to check
       # @return [Boolean]
+      def registered_resolver_for?(type)
+        !find(type).nil?
+      end
+
+      # Backward-compatible alias for {#registered_resolver_for?}.
       def handles?(type)
-        @resolvers.any? { |resolver| resolver.handles?(type) }
+        registered_resolver_for?(type)
       end
 
       # Iterates over all registered resolvers.
@@ -108,7 +114,16 @@ module GrapeOAS
 
       private
 
+      def find(type)
+        @resolvers.find { |resolver| resolver.handles?(type) }
+      end
+
       def validate_resolver!(resolver)
+        if resolver == DefaultResolver
+          raise ArgumentError,
+                "DefaultResolver is the built-in fallback and must not be registered in the chain"
+        end
+
         return if resolver.respond_to?(:handles?) && resolver.respond_to?(:build_schema)
 
         raise ArgumentError,

--- a/lib/grape_oas/type_resolvers/registry.rb
+++ b/lib/grape_oas/type_resolvers/registry.rb
@@ -78,8 +78,9 @@ module GrapeOAS
         !find(type).nil?
       end
 
-      # Backward-compatible alias for {#registered_resolver_for?}.
+      # @deprecated Use {#registered_resolver_for?} instead.
       def handles?(type)
+        warn "GrapeOAS::TypeResolvers::Registry#handles? is deprecated, use #registered_resolver_for? instead", uplevel: 1
         registered_resolver_for?(type)
       end
 

--- a/test/grape_oas/api_model_builders/path_test.rb
+++ b/test/grape_oas/api_model_builders/path_test.rb
@@ -271,9 +271,12 @@ module GrapeOAS
       def test_wildcard_path_converted_to_oas_template
         api_class = Class.new(Grape::API) do
           format :json
-          get "files/*path" do; end
-          get "a/:id/*rest" do; end
-          get "*all" do; end
+          get "files/*path" do
+          end
+          get "a/:id/*rest" do
+          end
+          get "*all" do
+          end
         end
 
         builder = Path.new(api: @api, routes: api_class.routes)

--- a/test/grape_oas/api_model_builders/path_test.rb
+++ b/test/grape_oas/api_model_builders/path_test.rb
@@ -271,12 +271,9 @@ module GrapeOAS
       def test_wildcard_path_converted_to_oas_template
         api_class = Class.new(Grape::API) do
           format :json
-          get "files/*path" do
-          end
-          get "a/:id/*rest" do
-          end
-          get "*all" do
-          end
+          get("files/*path") { nil }
+          get("a/:id/*rest") { nil }
+          get("*all") { nil }
         end
 
         builder = Path.new(api: @api, routes: api_class.routes)

--- a/test/grape_oas/api_model_builders/request_params_location_test.rb
+++ b/test/grape_oas/api_model_builders/request_params_location_test.rb
@@ -356,7 +356,7 @@ module GrapeOAS
         path_params = op.parameters.select { |p| p.location == "path" }
 
         assert(path_params.any? { |p| p.name == "path" },
-               "wildcard *path param should be classified as path location, not query")
+               "wildcard *path param should be classified as path location, not query",)
       end
 
       private

--- a/test/grape_oas/doc_key_normalizer_test.rb
+++ b/test/grape_oas/doc_key_normalizer_test.rb
@@ -46,7 +46,7 @@ module GrapeOAS
     def test_empty_hash_returns_empty_hash
       result = DocKeyNormalizer.normalize({})
 
-      assert_equal({}, result)
+      assert_empty(result)
     end
 
     def test_values_are_preserved

--- a/test/grape_oas/exporter/oas2_response_test.rb
+++ b/test/grape_oas/exporter/oas2_response_test.rb
@@ -12,7 +12,7 @@ module GrapeOAS
 
         result = Exporter::OAS2::Response.new([resp]).build
 
-        assert_equal({}, result["200"]["schema"])
+        assert_empty(result["200"]["schema"])
       end
 
       def test_includes_headers_and_examples

--- a/test/grape_oas/exporter/oas3_response_test.rb
+++ b/test/grape_oas/exporter/oas3_response_test.rb
@@ -12,7 +12,7 @@ module GrapeOAS
 
         result = Exporter::OAS3::Response.new([resp]).build
 
-        assert_equal({}, result["200"]["content"]["application/json"]["schema"])
+        assert_empty(result["200"]["content"]["application/json"]["schema"])
       end
 
       def test_headers_have_schema_wrapper

--- a/test/grape_oas/introspectors/entity_introspector_polymorphism_test.rb
+++ b/test/grape_oas/introspectors/entity_introspector_polymorphism_test.rb
@@ -203,7 +203,7 @@ module GrapeOAS
 
         result = EntityIntrospectorSupport.exposures(klass)
 
-        assert_equal [], result
+        assert_empty result
       end
     end
   end

--- a/test/grape_oas/introspectors/entity_introspector_support/type_schema_resolver_test.rb
+++ b/test/grape_oas/introspectors/entity_introspector_support/type_schema_resolver_test.rb
@@ -40,6 +40,29 @@ module GrapeOAS
           assert_equal Constants::SchemaTypes::STRING, schema.type
         end
 
+        # Regression: #67 — Date/DateTime/Time on entity exposures must
+        # produce the same type and format as on request params.
+        def test_datetime_class_produces_string_schema_with_date_time_format
+          schema = @resolver.build_exposure_base_schema(DateTime)
+
+          assert_equal Constants::SchemaTypes::STRING, schema.type
+          assert_equal "date-time", schema.format
+        end
+
+        def test_date_class_produces_string_schema_with_date_format
+          schema = @resolver.build_exposure_base_schema(Date)
+
+          assert_equal Constants::SchemaTypes::STRING, schema.type
+          assert_equal "date", schema.format
+        end
+
+        def test_time_class_produces_string_schema_with_date_time_format
+          schema = @resolver.build_exposure_base_schema(Time)
+
+          assert_equal Constants::SchemaTypes::STRING, schema.type
+          assert_equal "date-time", schema.format
+        end
+
         # === Hash / Hash class produces object schema ===
 
         def test_hash_class_produces_object_schema

--- a/test/grape_oas/introspectors/entity_introspector_support/type_schema_resolver_test.rb
+++ b/test/grape_oas/introspectors/entity_introspector_support/type_schema_resolver_test.rb
@@ -70,6 +70,13 @@ module GrapeOAS
           assert_equal Constants::SchemaTypes::INTEGER, schema.items.type
         end
 
+        def test_empty_array_literal_defaults_to_string_items
+          schema = @resolver.build_exposure_base_schema([])
+
+          assert_equal Constants::SchemaTypes::ARRAY, schema.type
+          assert_equal Constants::SchemaTypes::STRING, schema.items.type
+        end
+
         # === String-to-entity resolution with a valid entity class ===
 
         def test_string_type_resolving_to_entity_produces_object_schema

--- a/test/grape_oas/type_resolvers/default_resolver_test.rb
+++ b/test/grape_oas/type_resolvers/default_resolver_test.rb
@@ -31,6 +31,14 @@ module GrapeOAS
 
         assert_equal Constants::SchemaTypes::STRING, schema.type
       end
+
+      def test_logs_debug_message_on_fallback
+        output = capture_grape_oas_log(level: Logger::DEBUG) do
+          DefaultResolver.build_schema("MyUnknownType")
+        end
+
+        assert_match(/No type resolver matched.*MyUnknownType/, output)
+      end
     end
   end
 end

--- a/test/grape_oas/type_resolvers/default_resolver_test.rb
+++ b/test/grape_oas/type_resolvers/default_resolver_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GrapeOAS
+  module TypeResolvers
+    class DefaultResolverTest < Minitest::Test
+      def test_handles_any_type
+        assert DefaultResolver.handles?("anything")
+        assert DefaultResolver.handles?(String)
+        assert DefaultResolver.handles?(nil)
+        assert DefaultResolver.handles?(42)
+      end
+
+      def test_builds_string_schema
+        schema = DefaultResolver.build_schema("UnknownType")
+
+        assert_equal Constants::SchemaTypes::STRING, schema.type
+        assert_nil schema.format
+      end
+
+      def test_builds_string_schema_for_class
+        unknown = Class.new
+        schema = DefaultResolver.build_schema(unknown)
+
+        assert_equal Constants::SchemaTypes::STRING, schema.type
+      end
+
+      def test_builds_string_schema_for_nil
+        schema = DefaultResolver.build_schema(nil)
+
+        assert_equal Constants::SchemaTypes::STRING, schema.type
+      end
+    end
+  end
+end

--- a/test/grape_oas/type_resolvers/primitive_resolver_test.rb
+++ b/test/grape_oas/type_resolvers/primitive_resolver_test.rb
@@ -135,10 +135,44 @@ module GrapeOAS
         assert_equal Constants::SchemaTypes::INTEGER, schema.type
       end
 
-      def test_unknown_type_defaults_to_string
-        schema = PrimitiveResolver.build_schema("UnknownType")
+      def test_unknown_type_returns_nil
+        assert_nil PrimitiveResolver.build_schema("UnknownType")
+      end
 
-        assert_equal Constants::SchemaTypes::STRING, schema.type
+      # === Consistency: PRIMITIVES and Constants::PRIMITIVE_TYPE_MAPPING ===
+
+      def test_primitives_and_constants_agree_on_overlapping_types
+        # PRIMITIVES → Constants direction
+        PrimitiveResolver::PRIMITIVES.each do |type_name, mapping|
+          constants_type = Constants.primitive_type(type_name)
+          next unless constants_type
+
+          assert_equal mapping[:type], constants_type,
+            "Type mismatch for #{type_name}: PRIMITIVES says #{mapping[:type]}, " \
+            "Constants says #{constants_type}"
+
+          constants_format = Constants.format_for_type(type_name)
+          if mapping[:format].nil?
+            assert_nil constants_format,
+              "Format mismatch for #{type_name}: PRIMITIVES says nil, " \
+              "Constants says #{constants_format.inspect}"
+          else
+            assert_equal mapping[:format], constants_format,
+              "Format mismatch for #{type_name}: PRIMITIVES says #{mapping[:format].inspect}, " \
+              "Constants says #{constants_format.inspect}"
+          end
+        end
+
+        # Constants → PRIMITIVES direction (only for keys that are Ruby class names)
+        primitives_downcased = PrimitiveResolver::PRIMITIVES.transform_keys(&:downcase)
+        Constants::PRIMITIVE_TYPE_MAPPING.each do |key, entry|
+          mapping = primitives_downcased[key]
+          next unless mapping
+
+          assert_equal mapping[:type], entry[:type],
+            "Type mismatch for #{key}: Constants says #{entry[:type]}, " \
+            "PRIMITIVES says #{mapping[:type]}"
+        end
       end
 
       def test_handles_does_not_raise_when_date_constants_are_missing

--- a/test/grape_oas/type_resolvers/primitive_resolver_test.rb
+++ b/test/grape_oas/type_resolvers/primitive_resolver_test.rb
@@ -148,18 +148,18 @@ module GrapeOAS
           next unless constants_type
 
           assert_equal mapping[:type], constants_type,
-            "Type mismatch for #{type_name}: PRIMITIVES says #{mapping[:type]}, " \
-            "Constants says #{constants_type}"
+                       "Type mismatch for #{type_name}: PRIMITIVES says #{mapping[:type]}, " \
+                       "Constants says #{constants_type}"
 
           constants_format = Constants.format_for_type(type_name)
           if mapping[:format].nil?
             assert_nil constants_format,
-              "Format mismatch for #{type_name}: PRIMITIVES says nil, " \
-              "Constants says #{constants_format.inspect}"
+                       "Format mismatch for #{type_name}: PRIMITIVES says nil, " \
+                       "Constants says #{constants_format.inspect}"
           else
             assert_equal mapping[:format], constants_format,
-              "Format mismatch for #{type_name}: PRIMITIVES says #{mapping[:format].inspect}, " \
-              "Constants says #{constants_format.inspect}"
+                         "Format mismatch for #{type_name}: PRIMITIVES says #{mapping[:format].inspect}, " \
+                         "Constants says #{constants_format.inspect}"
           end
         end
 
@@ -170,8 +170,8 @@ module GrapeOAS
           next unless mapping
 
           assert_equal mapping[:type], entry[:type],
-            "Type mismatch for #{key}: Constants says #{entry[:type]}, " \
-            "PRIMITIVES says #{mapping[:type]}"
+                       "Type mismatch for #{key}: Constants says #{entry[:type]}, " \
+                       "PRIMITIVES says #{mapping[:type]}"
         end
       end
 

--- a/test/grape_oas/type_resolvers/registry_test.rb
+++ b/test/grape_oas/type_resolvers/registry_test.rb
@@ -64,6 +64,11 @@ module GrapeOAS
         assert_match(/must respond to/, error.message)
       end
 
+      def test_register_rejects_default_resolver
+        error = assert_raises(ArgumentError) { @registry.register(DefaultResolver) }
+        assert_match(/must not be registered/, error.message)
+      end
+
       def test_register_before_inserts_at_correct_position
         @registry.register(MockResolver)
         @registry.register(AnotherMockResolver, before: MockResolver)
@@ -87,22 +92,30 @@ module GrapeOAS
         assert_equal 0, @registry.size
       end
 
-      # === Finding tests ===
+      # === Resolver lookup tests ===
 
-      def test_find_returns_matching_resolver
+      def test_registered_resolver_for_returns_true_for_matching_resolver
         @registry.register(MockResolver)
 
-        result = @registry.find(:mock)
-
-        assert_equal MockResolver, result
+        assert @registry.registered_resolver_for?(:mock)
       end
 
-      def test_find_returns_nil_for_no_match
+      def test_registered_resolver_for_returns_false_for_no_match
         @registry.register(MockResolver)
 
-        result = @registry.find(:unknown)
+        refute @registry.registered_resolver_for?(:unknown)
+      end
 
-        assert_nil result
+      def test_handles_returns_true_for_matching_registered_resolver
+        @registry.register(MockResolver)
+
+        assert @registry.handles?(:mock)
+      end
+
+      def test_handles_returns_false_for_no_match
+        @registry.register(MockResolver)
+
+        refute @registry.handles?(:unknown)
       end
 
       # === build_schema tests ===
@@ -116,22 +129,32 @@ module GrapeOAS
         assert_equal "mock", schema.description
       end
 
-      def test_build_schema_returns_nil_for_no_match
-        result = @registry.build_schema(:unknown)
+      def test_build_schema_skips_resolver_that_handles_but_returns_nil
+        # Resolver claims to handle :flaky but returns nil from build_schema
+        flaky = Class.new do
+          extend Base
 
-        assert_nil result
-      end
+          def self.handles?(type)
+            type == :flaky
+          end
 
-      # === handles? tests ===
+          def self.build_schema(_type)
+            nil
+          end
+        end
 
-      def test_handles_returns_true_when_resolver_found
+        @registry.register(flaky)
         @registry.register(MockResolver)
 
-        assert @registry.handles?(:mock)
+        schema = @registry.build_schema(:flaky)
+
+        assert_equal Constants::SchemaTypes::STRING, schema.type
       end
 
-      def test_handles_returns_false_when_no_resolver
-        refute @registry.handles?(:unknown)
+      def test_build_schema_falls_back_to_default_resolver_for_no_match
+        schema = @registry.build_schema(:unknown)
+
+        assert_equal Constants::SchemaTypes::STRING, schema.type
       end
 
       # === Enumerable tests ===

--- a/test/grape_oas/type_resolvers/registry_test.rb
+++ b/test/grape_oas/type_resolvers/registry_test.rb
@@ -106,16 +106,12 @@ module GrapeOAS
         refute @registry.registered_resolver_for?(:unknown)
       end
 
-      def test_handles_returns_true_for_matching_registered_resolver
+      def test_handles_emits_deprecation_warning
         @registry.register(MockResolver)
 
-        assert @registry.handles?(:mock)
-      end
-
-      def test_handles_returns_false_for_no_match
-        @registry.register(MockResolver)
-
-        refute @registry.handles?(:unknown)
+        assert_output(nil, /deprecated.*registered_resolver_for\?/) do
+          @registry.handles?(:mock)
+        end
       end
 
       # === build_schema tests ===


### PR DESCRIPTION
## Problem

`GrapeOAS.type_resolvers` is a first-match-wins registry that converts request parameter types into rich schemas (Dry::Types, custom UUIDs, primitives). Entity exposures never consult it: when an exposure's declared type is a class that is neither a `Grape::Entity` nor a known primitive, TypeSchemaResolver falls back to bare `{ type: "string" }` through its own `build_schema_for_primitive` and `default_string_schema` methods — completely bypassing any custom resolvers registered in the chain.

## Fix

Replace the three separate fallback paths in TypeSchemaResolver (Class, String, else) with a single delegation to `GrapeOAS.type_resolvers.build_schema(type)`. The scattered `default_string_schema` and `build_schema_for_primitive` methods are removed.

To make this work without nil propagation, a new `DefaultResolver` acts as a built-in catch-all in `Registry#build_schema` — not registered in the chain (so it can't be accidentally unregistered), but always available as the terminal fallback. This lets callers drop their local `|| string_schema` guards.

`PrimitiveResolver` is extended to also handle OpenAPI type name aliases (`"object"`, `"number"`, `"boolean"`) via `Constants.primitive_type`, and its internals are consolidated into a single `find_mapping` method shared by `handles?` and `build_schema`.

Closes #67. Supersedes #90.

## Example

```ruby
class MyApp::Types::UUID; end

class MyUUIDResolver
  extend GrapeOAS::TypeResolvers::Base

  def self.handles?(type)
    type == MyApp::Types::UUID || type == "MyApp::Types::UUID"
  end

  def self.build_schema(_type)
    GrapeOAS::ApiModel::Schema.new(type: "string", format: "uuid")
  end
end

GrapeOAS.type_resolvers.register(MyUUIDResolver,
                                  before: GrapeOAS::TypeResolvers::PrimitiveResolver)

class FooEntity < Grape::Entity
  expose :id, documentation: { type: MyApp::Types::UUID }
end
```

## Schema before / after

```yaml
# Before — entity exposure ignores the registered resolver
components:
  schemas:
    FooEntity:
      type: object
      properties:
        id:
          type: string

# After — entity exposure consults the resolver chain
components:
  schemas:
    FooEntity:
      type: object
      properties:
        id:
          type: string
          format: uuid
```

## Backward compatibility

- Public API surface: `Registry#handles?` is deprecated in favor of `#registered_resolver_for?`; `Registry#find` is now private. `Registry#build_schema` now guarantees non-nil return (was `ApiModel::Schema, nil`). `PrimitiveResolver#build_schema` returns `nil` for unknown types instead of string schema.
- Emitted OAS shape for inputs not exercising this fix: unchanged — only entity exposures with custom type classes or OpenAPI type name aliases (`"object"`, `"number"`) gain format info they previously lacked.
- New runtime/dev dependencies: none.