### PR TITLE
Pin rubocop versions and add performance/packaging/rake plugins

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,8 @@
 plugins:
   - rubocop-minitest
+  - rubocop-packaging
+  - rubocop-performance
+  - rubocop-rake
 
 AllCops:
   TargetRubyVersion: 3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [#96](https://github.com/numbata/grape-oas/pull/96): Pin rubocop versions and add performance/packaging/rake plugins - [@numbata](https://github.com/numbata).
 - [#92](https://github.com/numbata/grape-oas/pull/92): Add cross-tool AI-agent contributor guidance and tighten gem file packaging - [@numbata](https://github.com/numbata).
 - Your contribution here
 

--- a/Gemfile
+++ b/Gemfile
@@ -26,8 +26,11 @@ group :development, :test do
   gem "rack"
   gem "rack-test"
   gem "rake"
-  gem "rubocop", require: false
-  gem "rubocop-minitest", require: false
+  gem "rubocop", "~> 1.86", require: false
+  gem "rubocop-minitest", "~> 0.38", require: false
+  gem "rubocop-packaging", "~> 0.5", require: false
+  gem "rubocop-performance", "~> 1.25", require: false
+  gem "rubocop-rake", "~> 0.6", require: false
 
   gem "danger", "~> 9", require: false
   gem "danger-changelog", "~> 0.8", require: false

--- a/lib/grape_oas/api_model_builder.rb
+++ b/lib/grape_oas/api_model_builder.rb
@@ -53,12 +53,12 @@ module GrapeOAS
     def build_registered_schemas(models)
       return [] unless models
 
-      Array(models).map do |model|
+      Array(models).filter_map do |model|
         model = model.constantize if model.is_a?(String)
         GrapeOAS.introspectors.build_schema(model, stack: [], registry: {})
       rescue StandardError
         nil
-      end.compact
+      end
     end
   end
 end

--- a/lib/grape_oas/api_model_builders/concerns/content_type_resolver.rb
+++ b/lib/grape_oas/api_model_builders/concerns/content_type_resolver.rb
@@ -24,7 +24,7 @@ module GrapeOAS
 
           mimes << mime_for_format(default_format) if mimes.empty? && default_format
 
-          mimes = mimes.map { |m| normalize_mime(m) }.compact
+          mimes = mimes.filter_map { |m| normalize_mime(m) }
           mimes.empty? ? [Constants::MimeTypes::JSON] : mimes.uniq
         end
 

--- a/lib/grape_oas/api_model_builders/operation.rb
+++ b/lib/grape_oas/api_model_builders/operation.rb
@@ -49,8 +49,7 @@ module GrapeOAS
           slug = route
                  .pattern
                  .origin
-                 .gsub(/[^a-z0-9]+/i, "_")
-                 .gsub(/_+/, "_")
+                 .gsub(/[^a-z0-9]+/i, "_").squeeze("_")
                  .sub(/^_|_$/, "")
 
           "#{http_method}_#{slug}"

--- a/lib/grape_oas/api_model_builders/response.rb
+++ b/lib/grape_oas/api_model_builders/response.rb
@@ -169,7 +169,7 @@ module GrapeOAS
 
       # Merges examples from multiple specs
       def merge_examples(specs)
-        examples = specs.map { |s| s[:examples] }.compact
+        examples = specs.filter_map { |s| s[:examples] }
         return nil if examples.empty?
 
         examples.reduce({}, :merge)

--- a/lib/grape_oas/exporter/oas2/parameter.rb
+++ b/lib/grape_oas/exporter/oas2/parameter.rb
@@ -84,13 +84,15 @@ module GrapeOAS
         def normalize_enum(enum_vals, type)
           return nil unless enum_vals.is_a?(Array)
 
-          coerced = enum_vals.filter_map do |v|
+          # rubocop:disable Performance/MapCompact -- filter_map drops `false` for boolean enums
+          coerced = enum_vals.map do |v|
             case type
             when Constants::SchemaTypes::INTEGER then v.to_i if v.respond_to?(:to_i)
             when Constants::SchemaTypes::NUMBER then v.to_f if v.respond_to?(:to_f)
             else v
             end
-          end
+          end.compact
+          # rubocop:enable Performance/MapCompact
 
           result = coerced.uniq
           return nil if result.empty?

--- a/lib/grape_oas/exporter/oas2/parameter.rb
+++ b/lib/grape_oas/exporter/oas2/parameter.rb
@@ -84,13 +84,13 @@ module GrapeOAS
         def normalize_enum(enum_vals, type)
           return nil unless enum_vals.is_a?(Array)
 
-          coerced = enum_vals.map do |v|
+          coerced = enum_vals.filter_map do |v|
             case type
             when Constants::SchemaTypes::INTEGER then v.to_i if v.respond_to?(:to_i)
             when Constants::SchemaTypes::NUMBER then v.to_f if v.respond_to?(:to_f)
             else v
             end
-          end.compact
+          end
 
           result = coerced.uniq
           return nil if result.empty?

--- a/lib/grape_oas/exporter/oas2/schema.rb
+++ b/lib/grape_oas/exporter/oas2/schema.rb
@@ -164,13 +164,13 @@ module GrapeOAS
         def normalize_enum(enum_vals, type)
           return nil unless enum_vals.is_a?(Array)
 
-          coerced = enum_vals.map do |v|
+          coerced = enum_vals.filter_map do |v|
             case type
             when Constants::SchemaTypes::INTEGER then v.to_i if v.respond_to?(:to_i)
             when Constants::SchemaTypes::NUMBER then v.to_f if v.respond_to?(:to_f)
             else v
             end
-          end.compact
+          end
 
           coerced.uniq
         end

--- a/lib/grape_oas/exporter/oas2/schema.rb
+++ b/lib/grape_oas/exporter/oas2/schema.rb
@@ -164,13 +164,15 @@ module GrapeOAS
         def normalize_enum(enum_vals, type)
           return nil unless enum_vals.is_a?(Array)
 
-          coerced = enum_vals.filter_map do |v|
+          # rubocop:disable Performance/MapCompact -- filter_map drops `false` for boolean enums
+          coerced = enum_vals.map do |v|
             case type
             when Constants::SchemaTypes::INTEGER then v.to_i if v.respond_to?(:to_i)
             when Constants::SchemaTypes::NUMBER then v.to_f if v.respond_to?(:to_f)
             else v
             end
-          end
+          end.compact
+          # rubocop:enable Performance/MapCompact
 
           coerced.uniq
         end

--- a/lib/grape_oas/exporter/oas3/schema.rb
+++ b/lib/grape_oas/exporter/oas3/schema.rb
@@ -243,13 +243,15 @@ module GrapeOAS
         def normalize_enum(enum_vals, type)
           return nil unless enum_vals.is_a?(Array)
 
-          coerced = enum_vals.filter_map do |v|
+          # rubocop:disable Performance/MapCompact -- filter_map drops `false` for boolean enums
+          coerced = enum_vals.map do |v|
             case type
             when Constants::SchemaTypes::INTEGER then v.to_i if v.respond_to?(:to_i)
             when Constants::SchemaTypes::NUMBER then v.to_f if v.respond_to?(:to_f)
             else v
             end
-          end
+          end.compact
+          # rubocop:enable Performance/MapCompact
 
           result = coerced.uniq
           return nil if result.empty?

--- a/lib/grape_oas/exporter/oas3/schema.rb
+++ b/lib/grape_oas/exporter/oas3/schema.rb
@@ -243,13 +243,13 @@ module GrapeOAS
         def normalize_enum(enum_vals, type)
           return nil unless enum_vals.is_a?(Array)
 
-          coerced = enum_vals.map do |v|
+          coerced = enum_vals.filter_map do |v|
             case type
             when Constants::SchemaTypes::INTEGER then v.to_i if v.respond_to?(:to_i)
             when Constants::SchemaTypes::NUMBER then v.to_f if v.respond_to?(:to_f)
             else v
             end
-          end.compact
+          end
 
           result = coerced.uniq
           return nil if result.empty?
@@ -308,7 +308,7 @@ module GrapeOAS
           when Constants::SchemaTypes::NUMBER
             hash.delete("enum") unless enum_vals.all?(Numeric)
           when Constants::SchemaTypes::BOOLEAN
-            hash.delete("enum") unless enum_vals.all? { |v| [true, false].include?(v) }
+            hash.delete("enum") unless enum_vals.all? { |v| v == true || v == false } # rubocop:disable Style/MultipleComparison
           else # string and fallback
             hash.delete("enum") unless enum_vals.all?(String)
           end

--- a/test/integration/documentation_extension_test.rb
+++ b/test/integration/documentation_extension_test.rb
@@ -158,7 +158,7 @@ class DocumentationExtensionTest < Minitest::Test
 
     add_oas_documentation(
       oas_mount_path: "/docs",
-      host: ->(request) { request.host =~ /staging/ ? "staging-api.example.com" : "api.example.com" },
+      host: ->(request) { request.host.include?("staging") ? "staging-api.example.com" : "api.example.com" },
       base_path: ->(request) { request.path_info.start_with?("/v2") ? "/v2" : "/v1" },
     )
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,7 +28,6 @@ end
 
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
-require "bundler/setup"
 Bundler.setup :default, :test
 
 require "minitest/autorun"


### PR DESCRIPTION
## Summary

Stabilizes the developer experience by pinning rubocop gem versions with pessimistic constraints and adding three new rubocop plugins (performance, packaging, rake) that catch suboptimal patterns and gem hygiene issues. The plugins found and autocorrected 11 offenses across the codebase.

## Problem

Unpinned rubocop and rubocop-minitest could introduce surprise cop changes on `bundle update`, breaking CI or requiring unplanned cleanup. The project also lacked static analysis for common performance anti-patterns and gem packaging hygiene.

## Fix

- Pin `rubocop` (\~> 1.86), `rubocop-minitest` (\~> 0.38) to current minor versions
- Add `rubocop-performance` (\~> 1.25), `rubocop-packaging` (\~> 0.5), `rubocop-rake` (\~> 0.6)
- Autocorrect all offenses: `map+compact` → `filter_map`, `gsub` → `squeeze`, redundant `bundler/setup`, regex → `String#include?`

## Backward compatibility

No user-facing API changes. Only dev tooling and internal implementation details (same behavior, more idiomatic code).