### PR TITLE
Default OAS 2.0 nullable strategy to EXTENSION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#97](https://github.com/numbata/grape-oas/pull/97): Default OAS 2.0 nullable strategy to EXTENSION so nullable fields emit `x-nullable: true` without explicit opt-in - [@numbata](https://github.com/numbata).
 - [#79](https://github.com/numbata/grape-oas/pull/79): Fix docs: `nickname` is supported in grape-oas - [@bogdan](https://github.com/bogdan).
 - [#78](https://github.com/numbata/grape-oas/pull/78): Fix: use empty schema for undocumented responses instead of `{ type: string }` - [@bogdan](https://github.com/bogdan).
 - [#74](https://github.com/numbata/grape-oas/pull/74): Fix BigDecimal range bounds serializing as JSON strings - [@olivier-thatch](https://github.com/olivier-thatch).

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -73,19 +73,18 @@ Control how nullable fields are represented in the generated schema. Each OpenAP
 |----------|--------|-------------|
 | `:keyword` | `"nullable": true` | OAS 3.0 |
 | `:type_array` | `"type": ["string", "null"]` | OAS 3.1 (always) |
-| `:extension` | `"x-nullable": true` | _(none)_ |
+| `:extension` | `"x-nullable": true` | OAS 2.0 |
 
 ```ruby
+# OAS 2.0 — default uses "x-nullable: true" extension
+GrapeOAS.generate(app: API, schema_type: :oas2)
+
 # OAS 3.0 — default uses "nullable: true" keyword
 GrapeOAS.generate(app: API, schema_type: :oas3)
 
 # OAS 3.0 — use JSON Schema null unions instead
 GrapeOAS.generate(app: API, schema_type: :oas3,
                   nullable_strategy: :type_array)
-
-# OAS 2.0 — emit x-nullable extension for nullable fields
-GrapeOAS.generate(app: API, schema_type: :oas2,
-                  nullable_strategy: :extension)
 
 # OAS 3.1 — always uses type arrays, nullable_strategy is ignored
 GrapeOAS.generate(app: API, schema_type: :oas31)
@@ -102,7 +101,7 @@ The legacy `nullable_keyword` option is still accepted for OAS 3.0 and mapped au
 | `nullable_keyword: true` | `nullable_strategy: :keyword` |
 | `nullable_keyword: false` | `nullable_strategy: :type_array` |
 
-If both `nullable_strategy` and `nullable_keyword` are provided, `nullable_strategy` takes precedence. The `nullable_keyword` option has no effect on OAS 2.0 or OAS 3.1.
+If both `nullable_strategy` and `nullable_keyword` are provided, `nullable_strategy` takes precedence. The `nullable_keyword` option has no effect on OAS 3.1 (which always uses `:type_array`). For OAS 2.0, `nullable_keyword` maps to `:extension` regardless of its value, since `:extension` is the only valid strategy for Swagger 2.0.
 
 ## Security Definitions
 

--- a/docs/EXPORTERS.md
+++ b/docs/EXPORTERS.md
@@ -30,7 +30,7 @@ schema = GrapeOAS.generate(app: MyAPI, schema_type: :oas31)
 - Request body via `in: body` parameters
 - `definitions` for schema references
 - `host`, `basePath`, `schemes` for server info
-- No built-in nullable support; use `nullable_strategy: :extension` to emit `x-nullable: true`
+- `x-nullable: true` for nullable types (default); configurable via `nullable_strategy`
 - **Composition types**: Not all composition types are natively supported. The exporter uses a fallback type while preserving schema extensions for downstream consumers
 
 #### OpenAPI 3.0

--- a/lib/grape_oas.rb
+++ b/lib/grape_oas.rb
@@ -195,12 +195,12 @@ module GrapeOAS
     if options[:nullable_strategy].nil? && options.key?(:nullable_keyword)
       options[:nullable_strategy] = case schema_type
                                     when :oas2, :oas20
-                                      Constants::NullableStrategy::EXTENSION
+                                      Constants::NullableStrategy::OAS2_DEFAULT
                                     when :oas3, :oas30
                                       if options[:nullable_keyword] == false
                                         Constants::NullableStrategy::TYPE_ARRAY
                                       else
-                                        Constants::NullableStrategy::KEYWORD
+                                        Constants::NullableStrategy::OAS3_DEFAULT
                                       end
                                     end
     end

--- a/lib/grape_oas.rb
+++ b/lib/grape_oas.rb
@@ -202,8 +202,6 @@ module GrapeOAS
                                       else
                                         Constants::NullableStrategy::KEYWORD
                                       end
-                                    when :oas31 # ignored for OAS 3.1 which always uses type arrays
-                                      Constants::NullableStrategy::TYPE_ARRAY
                                     end
     end
 

--- a/lib/grape_oas.rb
+++ b/lib/grape_oas.rb
@@ -202,6 +202,8 @@ module GrapeOAS
                                       else
                                         Constants::NullableStrategy::OAS3_DEFAULT
                                       end
+                                    when :oas31
+                                      Constants::NullableStrategy::OAS31_DEFAULT
                                     end
     end
 

--- a/lib/grape_oas.rb
+++ b/lib/grape_oas.rb
@@ -194,7 +194,7 @@ module GrapeOAS
   def generate(app:, schema_type: :oas3, **options)
     if options[:nullable_strategy].nil? && options.key?(:nullable_keyword)
       options[:nullable_strategy] = case schema_type
-                                    when :oas2, :oas20
+                                    when :oas2
                                       Constants::NullableStrategy::OAS2_DEFAULT
                                     when :oas3, :oas30
                                       if options[:nullable_keyword] == false

--- a/lib/grape_oas.rb
+++ b/lib/grape_oas.rb
@@ -192,11 +192,18 @@ module GrapeOAS
   #   # Only includes paths like /users, /users/{id}, etc.
   #
   def generate(app:, schema_type: :oas3, **options)
-    if options[:nullable_strategy].nil? && options.key?(:nullable_keyword) && %i[oas3 oas30].include?(schema_type)
-      options[:nullable_strategy] = if options[:nullable_keyword] == false
+    if options[:nullable_strategy].nil? && options.key?(:nullable_keyword)
+      options[:nullable_strategy] = case schema_type
+                                    when :oas2, :oas20
+                                      Constants::NullableStrategy::EXTENSION
+                                    when :oas3, :oas30
+                                      if options[:nullable_keyword] == false
+                                        Constants::NullableStrategy::TYPE_ARRAY
+                                      else
+                                        Constants::NullableStrategy::KEYWORD
+                                      end
+                                    when :oas31 # ignored for OAS 3.1 which always uses type arrays
                                       Constants::NullableStrategy::TYPE_ARRAY
-                                    else
-                                      Constants::NullableStrategy::KEYWORD
                                     end
     end
 

--- a/lib/grape_oas/constants.rb
+++ b/lib/grape_oas/constants.rb
@@ -45,6 +45,11 @@ module GrapeOAS
       TYPE_ARRAY = :type_array
       # OAS 2.0: emits `"x-nullable": true` extension
       EXTENSION = :extension
+
+      # Version-specific defaults used by exporters
+      OAS2_DEFAULT = EXTENSION
+      OAS3_DEFAULT = KEYWORD
+      OAS31_DEFAULT = TYPE_ARRAY
     end
 
     # Maximum number of elements to expand from a non-numeric Range into an enum array.

--- a/lib/grape_oas/exporter/oas2_schema.rb
+++ b/lib/grape_oas/exporter/oas2_schema.rb
@@ -67,7 +67,7 @@ module GrapeOAS
       end
 
       def nullable_strategy
-        @api.nullable_strategy || Constants::NullableStrategy::EXTENSION
+        @api.nullable_strategy || Constants::NullableStrategy::OAS2_DEFAULT
       end
 
       def build_paths

--- a/lib/grape_oas/exporter/oas2_schema.rb
+++ b/lib/grape_oas/exporter/oas2_schema.rb
@@ -67,7 +67,7 @@ module GrapeOAS
       end
 
       def nullable_strategy
-        @api.nullable_strategy
+        @api.nullable_strategy || Constants::NullableStrategy::EXTENSION
       end
 
       def build_paths

--- a/lib/grape_oas/exporter/oas31_schema.rb
+++ b/lib/grape_oas/exporter/oas31_schema.rb
@@ -29,7 +29,7 @@ module GrapeOAS
       def nullable_strategy
         # OAS 3.1 always uses JSON Schema null unions ("type": ["string", "null"]).
         # The "nullable" keyword and "x-nullable" extension are not valid in OAS 3.1.
-        Constants::NullableStrategy::TYPE_ARRAY
+        Constants::NullableStrategy::OAS31_DEFAULT
       end
     end
   end

--- a/lib/grape_oas/exporter/oas3_schema.rb
+++ b/lib/grape_oas/exporter/oas3_schema.rb
@@ -120,7 +120,7 @@ module GrapeOAS
       end
 
       def nullable_strategy
-        @api.nullable_strategy || Constants::NullableStrategy::KEYWORD
+        @api.nullable_strategy || Constants::NullableStrategy::OAS3_DEFAULT
       end
     end
   end

--- a/test/e2e/generate_oas2_complex_test.rb
+++ b/test/e2e/generate_oas2_complex_test.rb
@@ -526,16 +526,39 @@ module GrapeOAS
       assert status_prop["x-nullable"], "nullable contract field should have x-nullable"
     end
 
-    def test_default_oas2_does_not_emit_x_nullable
-      # Without nullable_strategy, nullable fields should not have x-nullable
+    def test_default_oas2_emits_x_nullable
+      # Default OAS 2.0 strategy is EXTENSION — nullable fields get x-nullable
       defs = @schema["definitions"]
       detail_def = defs[defs.keys.find { |k| k.include?("DetailEntity") }]
       zip_prop = detail_def["properties"]["zip"]
 
-      refute zip_prop.key?("x-nullable"), "default OAS2 should not emit x-nullable"
+      assert zip_prop["x-nullable"], "default OAS2 should emit x-nullable on nullable fields"
+      refute detail_def["properties"]["city"].key?("x-nullable"), "non-nullable field should not have x-nullable"
     end
 
     # --- backward compatibility: nullable_keyword option ---
+
+    def test_legacy_nullable_keyword_false_with_oas2_maps_to_extension
+      schema = GrapeOAS.generate(app: API, schema_type: :oas2, nullable_keyword: false)
+      defs = schema["definitions"]
+
+      detail_def = defs[defs.keys.find { |k| k.include?("DetailEntity") }]
+      zip_prop = detail_def["properties"]["zip"]
+
+      assert zip_prop["x-nullable"], "nullable_keyword: false with OAS 2.0 should produce x-nullable"
+      assert_equal "string", zip_prop["type"]
+    end
+
+    def test_legacy_nullable_keyword_true_with_oas2_maps_to_extension
+      schema = GrapeOAS.generate(app: API, schema_type: :oas2, nullable_keyword: true)
+      defs = schema["definitions"]
+
+      detail_def = defs[defs.keys.find { |k| k.include?("DetailEntity") }]
+      zip_prop = detail_def["properties"]["zip"]
+
+      assert zip_prop["x-nullable"], "nullable_keyword: true with OAS 2.0 should produce x-nullable"
+      assert_equal "string", zip_prop["type"]
+    end
 
     def test_legacy_nullable_keyword_false_maps_to_type_array
       schema = GrapeOAS.generate(app: API, schema_type: :oas3, nullable_keyword: false)

--- a/test/grape_oas/exporter/oas2_schema_test.rb
+++ b/test/grape_oas/exporter/oas2_schema_test.rb
@@ -651,7 +651,7 @@ module GrapeOAS
       end
     end
 
-    class OAS2SchemaExporterTest < Minitest::Test
+    class OAS2NullableDefaultStrategyTest < Minitest::Test
       def test_nullable_strategy_defaults_to_extension_when_api_has_no_strategy
         api = ApiModel::API.new(title: "Test", version: "1.0")
         exporter = Exporter::OAS2Schema.new(api_model: api)

--- a/test/grape_oas/exporter/oas2_schema_test.rb
+++ b/test/grape_oas/exporter/oas2_schema_test.rb
@@ -650,5 +650,22 @@ module GrapeOAS
         assert_equal 2, offset["maximum"]
       end
     end
+
+    class OAS2SchemaExporterTest < Minitest::Test
+      def test_nullable_strategy_defaults_to_extension_when_api_has_no_strategy
+        api = ApiModel::API.new(title: "Test", version: "1.0")
+        exporter = Exporter::OAS2Schema.new(api_model: api)
+
+        assert_equal Constants::NullableStrategy::EXTENSION, exporter.send(:nullable_strategy)
+      end
+
+      def test_nullable_strategy_uses_api_value_when_set
+        api = ApiModel::API.new(title: "Test", version: "1.0")
+        api.nullable_strategy = Constants::NullableStrategy::KEYWORD
+        exporter = Exporter::OAS2Schema.new(api_model: api)
+
+        assert_equal Constants::NullableStrategy::KEYWORD, exporter.send(:nullable_strategy)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

OAS 2.0 spec generation silently dropped nullable annotations because the exporter had no fallback strategy, unlike OAS 3.0 and 3.1 which both provide sensible defaults. This change defaults OAS 2.0 to the EXTENSION strategy so nullable fields automatically emit `x-nullable: true` without requiring explicit opt-in, bringing consistency across all three OAS versions.

## Problem

When generating OAS 2.0 specs, nullable fields produce no nullable annotation in the output unless `nullable_strategy: :extension` is explicitly passed. The default output silently loses nullability information — inconsistent with OAS 3.0 (falls back to `:keyword`) and OAS 3.1 (hard-overrides to `:type_array`).

## Fix

- Add a fallback to `EXTENSION` in `OAS2Schema#nullable_strategy`, matching the pattern used by OAS 3.0 and OAS 3.1 exporters.
- Extend the `nullable_keyword` legacy shim in `GrapeOAS.generate` to resolve the correct strategy for all schema types (previously only handled `:oas3`/`:oas30`).

## Example

```ruby
class UserEntity < Grape::Entity
  expose :nickname, documentation: { type: String, nullable: true }
end

class API < Grape::API
  format :json
  resource :users do
    desc "Get user", entity: UserEntity
    get { { nickname: nil } }
  end
end

spec = GrapeOAS.generate(app: API, schema_type: :oas2)
puts spec.dig("definitions", "UserEntity", "properties", "nickname")
```

## Schema before / after

**Before:**
```yaml
nickname:
  type: string
```

**After:**
```yaml
nickname:
  type: string
  x-nullable: true
```

## Backward compatibility

This is a behavioral change: OAS 2.0 output now includes `x-nullable: true` on nullable fields by default. The previous behavior (silently dropping nullable annotations) was never documented or intentional — it was a bug caused by a missing default.

Closes #91