### PR TITLE
Honor `documentation: { x: { nullable: true } }` on entity exposures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#76](https://github.com/numbata/grape-oas/pull/76): Emit OAS-version-correct schema for file types - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#82](https://github.com/numbata/grape-oas/pull/82): Fix: respect `documentation: { hidden: true }` on entity exposures - [@bogdan](https://github.com/bogdan).
 - [#80](https://github.com/numbata/grape-oas/pull/80): Fix: hide documentation routes from generated spec by default - [@bogdan](https://github.com/bogdan).
+- [#98](https://github.com/numbata/grape-oas/pull/98): Honor `documentation: { x: { nullable: true } }` on entity exposures - [@olivier-thatch](https://github.com/olivier-thatch).
 * Your contribution here
 
 ### Changed

--- a/lib/grape_oas/api_model_builders/concerns/oas_utilities.rb
+++ b/lib/grape_oas/api_model_builders/concerns/oas_utilities.rb
@@ -24,6 +24,19 @@ module GrapeOAS
           OasUtilities.extract_extensions(hash)
         end
 
+        # Extracts nullable flag from a documentation hash.
+        #
+        # @param doc [Hash] the documentation hash
+        # @return [Boolean] true if nullable
+        def self.extract_nullable(doc)
+          doc[:nullable] || (doc[:x].is_a?(Hash) && doc[:x][:nullable]) || false
+        end
+
+        # Instance method version
+        def extract_nullable(doc)
+          OasUtilities.extract_nullable(doc)
+        end
+
         # Converts a CamelCase string to snake_case.
         #
         # @param str [String] the string to convert

--- a/lib/grape_oas/api_model_builders/request_params_support/schema_enhancer.rb
+++ b/lib/grape_oas/api_model_builders/request_params_support/schema_enhancer.rb
@@ -24,15 +24,9 @@ module GrapeOAS
           apply_default(schema, spec, doc)
         end
 
-        # Extracts nullable flag from a documentation hash.
-        #
-        # @param doc [Hash] the documentation hash
-        # @return [Boolean] true if nullable
-        def self.extract_nullable(doc)
-          doc[:nullable] || (doc[:x].is_a?(Hash) && doc[:x][:nullable]) || false
-        end
-
         class << self
+          include GrapeOAS::ApiModelBuilders::Concerns::OasUtilities
+
           private
 
           def apply_additional_properties(schema, doc)

--- a/lib/grape_oas/introspectors/entity_introspector_support/exposure_processor.rb
+++ b/lib/grape_oas/introspectors/entity_introspector_support/exposure_processor.rb
@@ -205,7 +205,7 @@ module GrapeOAS
         end
 
         def apply_exposure_properties(schema, doc)
-          schema.nullable = doc[:nullable] || false
+          schema.nullable = PropertyExtractor.extract_nullable(doc)
           raw_values = doc[:values]
           if raw_values
             normalized = ValuesNormalizer.normalize(raw_values, context: "entity exposure values")

--- a/lib/grape_oas/introspectors/entity_introspector_support/property_extractor.rb
+++ b/lib/grape_oas/introspectors/entity_introspector_support/property_extractor.rb
@@ -7,6 +7,8 @@ module GrapeOAS
       # All methods are stateless and can be called directly on the class.
       class PropertyExtractor
         class << self
+          include GrapeOAS::ApiModelBuilders::Concerns::OasUtilities
+
           # Extracts description from a documentation hash.
           #
           # @param hash [Hash] the documentation hash
@@ -14,18 +16,6 @@ module GrapeOAS
           def extract_description(hash)
             desc = hash[:description] || hash[:desc]
             desc.is_a?(String) ? desc : nil
-          end
-
-          # Extracts nullable flag from a documentation hash.
-          # Supports both `documentation: { nullable: true }` and the
-          # `documentation: { x: { nullable: true } }` namespaced form.
-          #
-          # @param doc [Hash] the documentation hash
-          # @return [Boolean] true if nullable
-          def extract_nullable(doc)
-            doc[:nullable] || doc["nullable"] ||
-              (doc[:x].is_a?(Hash) && (doc[:x][:nullable] || doc[:x]["nullable"])) ||
-              false
           end
 
           # Extracts merge flag from exposure options and documentation.

--- a/lib/grape_oas/introspectors/entity_introspector_support/property_extractor.rb
+++ b/lib/grape_oas/introspectors/entity_introspector_support/property_extractor.rb
@@ -17,11 +17,15 @@ module GrapeOAS
           end
 
           # Extracts nullable flag from a documentation hash.
+          # Supports both `documentation: { nullable: true }` and the
+          # `documentation: { x: { nullable: true } }` namespaced form.
           #
           # @param doc [Hash] the documentation hash
           # @return [Boolean] true if nullable
           def extract_nullable(doc)
-            doc[:nullable] || doc["nullable"] || false
+            doc[:nullable] || doc["nullable"] ||
+              (doc[:x].is_a?(Hash) && (doc[:x][:nullable] || doc[:x]["nullable"])) ||
+              false
           end
 
           # Extracts merge flag from exposure options and documentation.

--- a/test/e2e/generate_oas2_test.rb
+++ b/test/e2e/generate_oas2_test.rb
@@ -34,5 +34,29 @@ module GrapeOAS
       assert_equal "path", parameters.first["in"]
       assert parameters.first["required"]
     end
+
+    class XNullableEntity < Grape::Entity
+      expose :note, documentation: { type: String, x: { nullable: true } }
+    end
+
+    class XNullableEntityAPI < Grape::API
+      format :json
+
+      namespace :notes do
+        get entity: XNullableEntity do
+          {}
+        end
+      end
+    end
+
+    def test_oas2_emits_x_nullable_for_entity_exposure_with_documentation_x_nullable
+      schema = GrapeOAS.generate(app: XNullableEntityAPI, schema_type: :oas2)
+      defs = schema["definitions"]
+      entity_def = defs[defs.keys.find { |k| k.include?("XNullableEntity") }]
+      note_prop = entity_def["properties"]["note"]
+
+      assert_equal "string", note_prop["type"]
+      assert note_prop["x-nullable"], "OAS 2.0 default (EXTENSION) should emit x-nullable for x: { nullable: true } on entity"
+    end
   end
 end

--- a/test/e2e/generate_oas31_test.rb
+++ b/test/e2e/generate_oas31_test.rb
@@ -32,5 +32,29 @@ module GrapeOAS
 
       assert_equal "query", params.first["in"]
     end
+
+    class XNullableEntity < Grape::Entity
+      expose :note, documentation: { type: String, x: { nullable: true } }
+    end
+
+    class XNullableEntityAPI < Grape::API
+      format :json
+
+      namespace :notes do
+        get entity: XNullableEntity do
+          {}
+        end
+      end
+    end
+
+    def test_oas31_emits_type_array_for_entity_exposure_with_documentation_x_nullable
+      schema = GrapeOAS.generate(app: XNullableEntityAPI, schema_type: :oas31)
+      components = schema.dig("components", "schemas")
+      entity_def = components[components.keys.find { |k| k.include?("XNullableEntity") }]
+      note_prop = entity_def["properties"]["note"]
+
+      assert_equal %w[string null], note_prop["type"], "OAS 3.1 should use type array for x: { nullable: true } on entity"
+      refute note_prop.key?("nullable"), "OAS 3.1 must not emit nullable keyword"
+    end
   end
 end

--- a/test/e2e/generate_oas3_test.rb
+++ b/test/e2e/generate_oas3_test.rb
@@ -38,5 +38,29 @@ module GrapeOAS
       # Confirm components container exists
       assert_kind_of Hash, schema["components"]
     end
+
+    class XNullableEntity < Grape::Entity
+      expose :note, documentation: { type: String, x: { nullable: true } }
+    end
+
+    class XNullableEntityAPI < Grape::API
+      format :json
+
+      namespace :notes do
+        get entity: XNullableEntity do
+          {}
+        end
+      end
+    end
+
+    def test_oas3_emits_nullable_for_entity_exposure_with_documentation_x_nullable
+      schema = GrapeOAS.generate(app: XNullableEntityAPI, schema_type: :oas3)
+      components = schema.dig("components", "schemas")
+      entity_def = components[components.keys.find { |k| k.include?("XNullableEntity") }]
+      note_prop = entity_def["properties"]["note"]
+
+      assert_equal "string", note_prop["type"]
+      assert note_prop["nullable"], "OAS 3.0 should emit nullable: true for documentation: { x: { nullable: true } } on entity exposure"
+    end
   end
 end

--- a/test/grape_oas/introspectors/entity_introspector_test.rb
+++ b/test/grape_oas/introspectors/entity_introspector_test.rb
@@ -184,6 +184,17 @@ module GrapeOAS
         assert_includes schema.required, "forced"
       end
 
+      def test_x_nullable_documentation_sets_nullable_on_entity_exposure
+        entity_class = Class.new(Grape::Entity) do
+          expose :note, documentation: { type: String, x: { nullable: true } }
+        end
+
+        schema = Introspectors::EntityIntrospector.new(entity_class).build_schema
+        note_schema = schema.properties["note"]
+
+        assert note_schema.nullable, "Expected x: { nullable: true } to set schema.nullable on entity exposure"
+      end
+
       def test_merge_flattens_properties
         schema = Introspectors::EntityIntrospector.new(ConditionalEntity).build_schema
 


### PR DESCRIPTION
## Problem

Entity exposures silently ignore `documentation: { x: { nullable: true } }`.
The `x:`-namespaced form already works on Grape `params` (via
`SchemaEnhancer.extract_nullable` in `request_params_support`), but the entity
introspector only honors the bare `documentation: { nullable: true }`. Users
who use the namespaced form consistently across params and entities get
correct output on the params side and a silent no-op on the entity side.

## Fix

Extend `EntityIntrospectorSupport::PropertyExtractor.extract_nullable` to also
recognize `doc[:x][:nullable]` (plus the string-keyed variants), matching the
shape of the params-side helper. Then route
`ExposureProcessor#apply_exposure_properties` through that helper instead of
its inline `doc[:nullable] || false`, so the same nullable-extraction logic
governs the entity-root path (which already used `PropertyExtractor`) and the
per-exposure path.

## Example

```ruby
class UserEntity < Grape::Entity
  expose :note, documentation: { type: String, x: { nullable: true } }
end

class API < Grape::API
  format :json
  get :user, entity: UserEntity do
    {}
  end
end
```

## Schema before / after

```yaml
# OAS 3.0 — Before: nullable flag silently dropped
components:
  schemas:
    UserEntity:
      type: object
      properties:
        note:
          type: string

# OAS 3.0 — After
components:
  schemas:
    UserEntity:
      type: object
      properties:
        note:
          type: string
          nullable: true
```

```yaml
# OAS 3.1 — Before: nullable flag silently dropped
components:
  schemas:
    UserEntity:
      type: object
      properties:
        note:
          type: string

# OAS 3.1 — After (3.1 always uses JSON Schema null unions)
components:
  schemas:
    UserEntity:
      type: object
      properties:
        note:
          type: ["string", "null"]
```

OAS 2.0 with the default `EXTENSION` strategy emits `x-nullable: true` on the
property; with `KEYWORD` it emits `nullable: true`. Same routing as the bare
`nullable: true` form — only the entrypoint changed.

## Backward compatibility

- Public API surface: unchanged.
- Emitted OAS shape for inputs that don't exercise this fix: unchanged.
  Entities already using `documentation: { nullable: true }`, or not setting
  nullable at all, produce byte-identical output. The only emitted-shape
  change is for entities that previously used
  `documentation: { x: { nullable: true } }` and got a silent no-op — those
  now correctly emit nullable, which is the documented behavior on the params
  side.
- New runtime/dev dependencies: none.