### PR TITLE
Fix: nullable entity ref must not mutate shared cached schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#98](https://github.com/numbata/grape-oas/pull/98): Honor `documentation: { x: { nullable: true } }` on entity exposures - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#85](https://github.com/numbata/grape-oas/pull/85): Honor `is_array: true` on the plain-entity response branch - [@abeljim8am](https://github.com/abeljim8am).
 - [#87](https://github.com/numbata/grape-oas/pull/87): Fix `SchemaIndexer#index_schema` to recurse into `schema.items` so entities reachable only through an array wrapper (e.g. a property declared as `Array<OtherEntity>`) are included in the indexed schemas set - [@abeljim8am](https://github.com/abeljim8am).
+- [#102](https://github.com/numbata/grape-oas/pull/102): Fix: nullable entity ref must not mutate shared cached schema - [@bogdan](https://github.com/bogdan).
 * Your contribution here
 
 ### Changed

--- a/lib/grape_oas/exporter/oas3/schema.rb
+++ b/lib/grape_oas/exporter/oas3/schema.rb
@@ -179,6 +179,19 @@ module GrapeOAS
             schema_hash["nullable"] = true
           when Constants::NullableStrategy::EXTENSION
             schema_hash["x-nullable"] = true
+          when Constants::NullableStrategy::TYPE_ARRAY
+            composition_key = %w[allOf oneOf anyOf].find { |k| schema_hash.key?(k) }
+            if schema_hash["type"].nil? && composition_key
+              # Adding type: ["null"] to an allOf/oneOf/anyOf wrapper would be
+              # conjunctive and can make the schema unsatisfiable. Wrap instead
+              # as anyOf: [{ <key>: [...] }, { type: "null" }].
+              schema_hash["anyOf"] = [
+                { composition_key => schema_hash.delete(composition_key) },
+                { "type" => "null" }
+              ]
+            else
+              schema_hash["type"] = (Array(schema_hash["type"]) | ["null"])
+            end
           end
         end
 

--- a/lib/grape_oas/introspectors/entity_introspector_support/exposure_processor.rb
+++ b/lib/grape_oas/introspectors/entity_introspector_support/exposure_processor.rb
@@ -205,7 +205,16 @@ module GrapeOAS
         end
 
         def apply_exposure_properties(schema, doc)
-          schema.nullable = PropertyExtractor.extract_nullable(doc)
+          nullable = PropertyExtractor.extract_nullable(doc)
+          if nullable && schema.respond_to?(:canonical_name) && schema.canonical_name
+            # Don't mutate the shared cached entity schema. Create a wrapper with
+            # all_of so the exporter emits { nullable: true, allOf: [{ $ref }] }.
+            # collect_refs traverses all_of and registers the original schema as a
+            # component, keeping its definition free of this property's nullable.
+            return ApiModel::Schema.new(nullable: true, all_of: [schema])
+          end
+
+          schema.nullable = nullable
           raw_values = doc[:values]
           if raw_values
             normalized = ValuesNormalizer.normalize(raw_values, context: "entity exposure values")

--- a/lib/grape_oas/introspectors/entity_introspector_support/exposure_processor.rb
+++ b/lib/grape_oas/introspectors/entity_introspector_support/exposure_processor.rb
@@ -206,15 +206,15 @@ module GrapeOAS
 
         def apply_exposure_properties(schema, doc)
           nullable = PropertyExtractor.extract_nullable(doc)
-          if nullable && schema.respond_to?(:canonical_name) && schema.canonical_name
+          if nullable && schema.canonical_name
             # Don't mutate the shared cached entity schema. Create a wrapper with
             # all_of so the exporter emits { nullable: true, allOf: [{ $ref }] }.
             # collect_refs traverses all_of and registers the original schema as a
             # component, keeping its definition free of this property's nullable.
-            return ApiModel::Schema.new(nullable: true, all_of: [schema])
+            schema = ApiModel::Schema.new(nullable: true, all_of: [schema])
+          else
+            schema.nullable = nullable
           end
-
-          schema.nullable = nullable
           raw_values = doc[:values]
           if raw_values
             normalized = ValuesNormalizer.normalize(raw_values, context: "entity exposure values")

--- a/test/grape_oas/exporter/oas31_schema_test.rb
+++ b/test/grape_oas/exporter/oas31_schema_test.rb
@@ -129,6 +129,22 @@ module GrapeOAS
         refute result.key?("format")
       end
 
+      def test_nullable_allof_wraps_as_any_of_with_null_sibling
+        ref = ApiModel::Schema.new(canonical_name: "Child")
+        schema = ApiModel::Schema.new(nullable: true, all_of: [ref])
+
+        result = OAS31::Schema.new(
+          schema, nil,
+          nullable_strategy: Constants::NullableStrategy::TYPE_ARRAY,
+        ).build
+
+        refute result.key?("allOf"), "bare allOf loses nullability — must be promoted to anyOf"
+        assert result.key?("anyOf")
+        assert_equal 2, result["anyOf"].size
+        assert result["anyOf"].any?({ "type" => "null" })
+        assert result["anyOf"].any? { |s| s.key?("allOf") }
+      end
+
       def test_allof_with_file_type_normalizes_to_content_keywords
         child = ApiModel::Schema.new(type: "object")
         schema = ApiModel::Schema.new(all_of: [child], type: "file")

--- a/test/grape_oas/exporter/oas31_schema_test.rb
+++ b/test/grape_oas/exporter/oas31_schema_test.rb
@@ -142,7 +142,7 @@ module GrapeOAS
         assert result.key?("anyOf")
         assert_equal 2, result["anyOf"].size
         assert result["anyOf"].any?({ "type" => "null" })
-        assert result["anyOf"].any? { |s| s.key?("allOf") }
+        assert(result["anyOf"].any? { |s| s.key?("allOf") })
       end
 
       def test_allof_with_file_type_normalizes_to_content_keywords

--- a/test/grape_oas/introspectors/entity_introspector_edge_cases_test.rb
+++ b/test/grape_oas/introspectors/entity_introspector_edge_cases_test.rb
@@ -678,6 +678,29 @@ module GrapeOAS
         assert_equal 0, score.minimum
         assert_equal 100, score.maximum
       end
+
+      # === Nullable entity ref must not mutate the shared schema ===
+
+      class SharedChildEntity < Grape::Entity
+        expose :id, documentation: { type: Integer }
+      end
+
+      class NullableRefParentEntity < Grape::Entity
+        expose :child,
+               using: SharedChildEntity,
+               documentation: { type: SharedChildEntity, x: { nullable: true } }
+      end
+
+      def test_nullable_ref_does_not_mutate_shared_child_schema
+        registry = {}
+        EntityIntrospector.build_schema(SharedChildEntity, registry: registry)
+        original_nullable = registry[SharedChildEntity].nullable
+
+        EntityIntrospector.build_schema(NullableRefParentEntity, registry: registry)
+
+        assert_equal original_nullable, registry[SharedChildEntity].nullable,
+                     "nullable exposure in parent must not mutate the shared child entity schema"
+      end
     end
   end
 end

--- a/test/grape_oas/introspectors/entity_introspector_edge_cases_test.rb
+++ b/test/grape_oas/introspectors/entity_introspector_edge_cases_test.rb
@@ -701,7 +701,7 @@ module GrapeOAS
         assert_equal original_nullable, registry[SharedChildEntity].nullable,
                      "nullable exposure in parent must not mutate the shared child entity schema"
 
-        child_schema = parent_schema.properties[:child] || parent_schema.properties["child"]
+        child_schema = parent_schema.properties["child"]
 
         assert child_schema.all_of, "nullable ref should produce an all_of wrapper"
         assert_equal "a nullable child", child_schema.description

--- a/test/grape_oas/introspectors/entity_introspector_edge_cases_test.rb
+++ b/test/grape_oas/introspectors/entity_introspector_edge_cases_test.rb
@@ -688,7 +688,7 @@ module GrapeOAS
       class NullableRefParentEntity < Grape::Entity
         expose :child,
                using: SharedChildEntity,
-               documentation: { type: SharedChildEntity, x: { nullable: true } }
+               documentation: { type: SharedChildEntity, x: { nullable: true }, desc: "a nullable child", example: { id: 1 } }
       end
 
       def test_nullable_ref_does_not_mutate_shared_child_schema
@@ -696,10 +696,15 @@ module GrapeOAS
         EntityIntrospector.build_schema(SharedChildEntity, registry: registry)
         original_nullable = registry[SharedChildEntity].nullable
 
-        EntityIntrospector.build_schema(NullableRefParentEntity, registry: registry)
+        parent_schema = EntityIntrospector.build_schema(NullableRefParentEntity, registry: registry)
 
         assert_equal original_nullable, registry[SharedChildEntity].nullable,
                      "nullable exposure in parent must not mutate the shared child entity schema"
+
+        child_schema = parent_schema.properties[:child] || parent_schema.properties["child"]
+        assert child_schema.all_of, "nullable ref should produce an all_of wrapper"
+        assert_equal "a nullable child", child_schema.description
+        assert_equal({ id: 1 }, child_schema.examples)
       end
     end
   end

--- a/test/grape_oas/introspectors/entity_introspector_edge_cases_test.rb
+++ b/test/grape_oas/introspectors/entity_introspector_edge_cases_test.rb
@@ -702,6 +702,7 @@ module GrapeOAS
                      "nullable exposure in parent must not mutate the shared child entity schema"
 
         child_schema = parent_schema.properties[:child] || parent_schema.properties["child"]
+
         assert child_schema.all_of, "nullable ref should produce an all_of wrapper"
         assert_equal "a nullable child", child_schema.description
         assert_equal({ id: 1 }, child_schema.examples)

--- a/test/grape_oas/oas_test.rb
+++ b/test/grape_oas/oas_test.rb
@@ -8,7 +8,7 @@ class GrapeOASTest < Minitest::Test
   end
 
   def test_module_defined
-    assert defined?(GrapeOAS)
+    assert(defined?(GrapeOAS))
   end
 
   def test_logger_returns_default_logger


### PR DESCRIPTION
## Problem

When an entity exposure references another entity with `x: { nullable: true }`, the shared cached schema object was mutated, causing `nullable: true` to bleed into the component definition.

**Minimal reproduce:**

```ruby
class ChildEntity < Grape::Entity
  expose :id, documentation: { type: Integer }
end

class ParentEntity < Grape::Entity
  expose :child, using: ChildEntity, documentation: { x: { nullable: true } }
end
```

**Buggy output** — `ChildEntity` in `components/schemas` incorrectly carries `nullable: true`:

```json
"components": {
  "schemas": {
    "ChildEntity": {
      "type": "object",
      "nullable": true,
      "properties": { "id": { "type": "integer" } }
    }
  }
},
"properties": {
  "child": {
    "nullable": true,
    "allOf": [{ "$ref": "#/components/schemas/ChildEntity" }]
  }
}
```

**Correct output:**

```json
"components": {
  "schemas": {
    "ChildEntity": {
      "type": "object",
      "properties": { "id": { "type": "integer" } }
    }
  }
},
"properties": {
  "child": {
    "nullable": true,
    "allOf": [{ "$ref": "#/components/schemas/ChildEntity" }]
  }
}
```