### PR TITLE
Feat: Add `array_use_braces` option for array param names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#96](https://github.com/numbata/grape-oas/pull/96): Pin rubocop versions and add performance/packaging/rake plugins - [@numbata](https://github.com/numbata).
 - [#92](https://github.com/numbata/grape-oas/pull/92): Add cross-tool AI-agent contributor guidance and tighten gem file packaging - [@numbata](https://github.com/numbata).
+- [#103](https://github.com/numbata/grape-oas/pull/103): Add `array_use_braces` option to append `[]` to array query params and form/multipart body property names - [@olivier-thatch](https://github.com/olivier-thatch).
 - Your contribution here
 
 ### Fixed

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -103,6 +103,31 @@ The legacy `nullable_keyword` option is still accepted for OAS 3.0 and mapped au
 
 If both `nullable_strategy` and `nullable_keyword` are provided, `nullable_strategy` takes precedence. The `nullable_keyword` option has no effect on OAS 3.1 (which always uses `:type_array`). For OAS 2.0, `nullable_keyword` maps to `:extension` regardless of its value, since `:extension` is the only valid strategy for Swagger 2.0.
 
+## Array Use Braces
+
+Some clients (Rails/PHP/`qs`-style) expect array request fields to be named with a trailing `[]` — e.g. `ids[]` instead of `ids`. Set `array_use_braces: true` to append `[]` to the **name** of array parameters that are:
+
+- query-string parameters (`in: query`), or
+- body properties served under `application/x-www-form-urlencoded` or `multipart/form-data`.
+
+JSON body properties (`application/json`), path parameters, and header parameters are never modified. The option defaults to `false`, so existing output is unchanged unless you opt in. It applies identically to OAS 2.0, 3.0, and 3.1.
+
+```ruby
+GrapeOAS.generate(app: API, schema_type: :oas3, array_use_braces: true)
+```
+
+For an array query parameter `ids`:
+
+```jsonc
+// array_use_braces: false (default)
+{ "name": "ids", "in": "query", "schema": { "type": "array", "items": { "type": "integer" } } }
+
+// array_use_braces: true
+{ "name": "ids[]", "in": "query", "schema": { "type": "array", "items": { "type": "integer" } } }
+```
+
+For a form-encoded body, only the array properties (and their `required` entries) gain `[]`; the `application/json` representation of the same body is left untouched (it keeps its shared `$ref`). When a form/multipart media type is braced, its schema is inlined so the rename does not affect the JSON-facing schema. Only top-level form properties are braced — nested object structures (uncommon in form encodings) are left as-is.
+
 ## Security Definitions
 
 Security definitions are passed through directly to the OpenAPI output. Use the format appropriate for your target OpenAPI version.

--- a/lib/grape_oas/api_model/api.rb
+++ b/lib/grape_oas/api_model/api.rb
@@ -11,7 +11,8 @@ module GrapeOAS
     class API < Node
       attr_accessor :title, :version, :paths, :servers, :tag_defs, :components,
                     :host, :base_path, :schemes, :security_definitions, :security,
-                    :registered_schemas, :suppress_default_error_response, :nullable_strategy
+                    :registered_schemas, :suppress_default_error_response, :nullable_strategy,
+                    :array_use_braces
 
       def initialize(title:, version:)
         super()
@@ -29,6 +30,7 @@ module GrapeOAS
         @registered_schemas = []
         @suppress_default_error_response = false
         @nullable_strategy = nil
+        @array_use_braces = false
       end
 
       def add_path(path)

--- a/lib/grape_oas/api_model_builder.rb
+++ b/lib/grape_oas/api_model_builder.rb
@@ -20,6 +20,7 @@ module GrapeOAS
       @api.registered_schemas = build_registered_schemas(options[:models])
       @api.suppress_default_error_response = options[:suppress_default_error_response] || false
       @api.nullable_strategy = options[:nullable_strategy]
+      @api.array_use_braces = options[:array_use_braces] || false
 
       @namespace_filter = options[:namespace]
       @apis = []

--- a/lib/grape_oas/exporter/base/array_braces.rb
+++ b/lib/grape_oas/exporter/base/array_braces.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module GrapeOAS
+  module Exporter
+    module Base
+      # Helpers for the `array_use_braces` option, which appends `[]` to the
+      # names of array parameters so clients that expect Rails/PHP-style array
+      # field names (e.g. `ids[]`) get them. Applied only to query-string
+      # parameters and form/multipart body properties — never to JSON bodies,
+      # path params, or header params.
+      module ArrayBraces
+        FORM_MIME_TYPES = [
+          Constants::MimeTypes::FORM_URLENCODED,
+          Constants::MimeTypes::MULTIPART_FORM
+        ].freeze
+
+        module_function
+
+        # Display name for a query-string parameter, with `[]` appended when the
+        # option is enabled and the parameter is an array.
+        def param_name(param, enabled:)
+          return param.name unless enabled
+          return param.name unless param.location == "query"
+          return param.name unless array_schema?(param.schema)
+
+          "#{param.name}[]"
+        end
+
+        def form_encoded?(mime_type)
+          FORM_MIME_TYPES.include?(mime_type)
+        end
+
+        # Rename top-level array property keys (and their `required` entries) on
+        # an already-emitted schema Hash to use the `[]` suffix. Mutates and
+        # returns the Hash. No-ops on `$ref` entries (no inline properties).
+        def apply_to_schema(schema_hash)
+          props = schema_hash["properties"]
+          return schema_hash unless props.is_a?(Hash)
+
+          rename_map = {}
+          renamed = props.each_with_object({}) do |(key, value), acc|
+            new_key = array_type?(value["type"]) ? "#{key}[]" : key
+            rename_map[key] = new_key
+            acc[new_key] = value
+          end
+          schema_hash["properties"] = renamed
+
+          required = schema_hash["required"]
+          schema_hash["required"] = required.map { |name| rename_map[name] || name } if required.is_a?(Array)
+
+          schema_hash
+        end
+
+        def array_schema?(schema)
+          schema.respond_to?(:type) && schema.type == Constants::SchemaTypes::ARRAY
+        end
+
+        def array_type?(type)
+          type == Constants::SchemaTypes::ARRAY ||
+            (type.is_a?(Array) && type.include?(Constants::SchemaTypes::ARRAY))
+        end
+      end
+    end
+  end
+end

--- a/lib/grape_oas/exporter/oas2/operation.rb
+++ b/lib/grape_oas/exporter/oas2/operation.rb
@@ -11,11 +11,13 @@ module GrapeOAS
         # OAS2-specific fields: consumes, produces, parameters (including body)
         def build_version_specific_fields
           strategy = @options[:nullable_strategy]
+          braces = @options[:array_use_braces] || false
 
           {
             "consumes" => consumes,
             "produces" => produces,
-            "parameters" => Parameter.new(@op, @ref_tracker, nullable_strategy: strategy).build,
+            "parameters" => Parameter.new(@op, @ref_tracker, nullable_strategy: strategy,
+                                                             array_use_braces: braces,).build,
             "responses" => Response.new(@op.responses, @ref_tracker, nullable_strategy: strategy).build
           }
         end

--- a/lib/grape_oas/exporter/oas2/parameter.rb
+++ b/lib/grape_oas/exporter/oas2/parameter.rb
@@ -18,10 +18,11 @@ module GrapeOAS
           "uuid" => { type: Constants::SchemaTypes::STRING, format: "uuid" }
         }.freeze
 
-        def initialize(operation, ref_tracker = nil, nullable_strategy: nil)
+        def initialize(operation, ref_tracker = nil, nullable_strategy: nil, array_use_braces: false)
           @op = operation
           @ref_tracker = ref_tracker
           @nullable_strategy = nullable_strategy
+          @array_use_braces = array_use_braces
         end
 
         def build
@@ -35,13 +36,14 @@ module GrapeOAS
         def build_parameter(param)
           type = param.schema&.type
           format = param.schema&.format
+          name = Base::ArrayBraces.param_name(param, enabled: @array_use_braces)
           primitive_types = PRIMITIVE_MAPPINGS.keys + %w[object string boolean file json array number]
           is_primitive = type && primitive_types.include?(type)
 
           if is_primitive && param.location != "body"
             mapping = PRIMITIVE_MAPPINGS[type]
             result = {
-              "name" => param.name,
+              "name" => name,
               "in" => param.location,
               "required" => param.required,
               "description" => param.description,
@@ -53,7 +55,7 @@ module GrapeOAS
             result.compact
           else
             {
-              "name" => param.name,
+              "name" => name,
               "in" => param.location,
               "required" => param.required,
               "description" => param.description,
@@ -135,7 +137,21 @@ module GrapeOAS
 
         def build_body_schema(request_body)
           mt = Array(request_body.media_types).first
-          mt ? build_schema_or_ref(mt.schema) : nil
+          return nil unless mt
+
+          # When array_use_braces is on and the body is form/multipart encoded, inline the
+          # schema (OAS 2.0 has a single body schema, normally a $ref) so we can append `[]`
+          # to its array property names without mutating the shared, JSON-facing definition.
+          if @array_use_braces && form_encoded_body?(request_body)
+            inline = Schema.new(mt.schema, @ref_tracker, nullable_strategy: @nullable_strategy).build
+            return Base::ArrayBraces.apply_to_schema(inline)
+          end
+
+          build_schema_or_ref(mt.schema)
+        end
+
+        def form_encoded_body?(request_body)
+          Array(request_body.media_types).any? { |mt| Base::ArrayBraces.form_encoded?(mt.mime_type) }
         end
 
         def build_schema_or_ref(schema)

--- a/lib/grape_oas/exporter/oas2/paths.rb
+++ b/lib/grape_oas/exporter/oas2/paths.rb
@@ -12,6 +12,7 @@ module GrapeOAS
         def build_operation(operation)
           Operation.new(operation, @ref_tracker,
                         nullable_strategy: @options[:nullable_strategy],
+                        array_use_braces: @options[:array_use_braces] || false,
                         suppress_default_error_response: @options[:suppress_default_error_response],).build
         end
       end

--- a/lib/grape_oas/exporter/oas2_schema.rb
+++ b/lib/grape_oas/exporter/oas2_schema.rb
@@ -70,9 +70,14 @@ module GrapeOAS
         @api.nullable_strategy || Constants::NullableStrategy::OAS2_DEFAULT
       end
 
+      def array_use_braces
+        @api.array_use_braces || false
+      end
+
       def build_paths
         OAS2::Paths.new(@api, @ref_tracker,
                         nullable_strategy: nullable_strategy,
+                        array_use_braces: array_use_braces,
                         suppress_default_error_response: @api.suppress_default_error_response,).build
       end
 

--- a/lib/grape_oas/exporter/oas3/operation.rb
+++ b/lib/grape_oas/exporter/oas3/operation.rb
@@ -11,10 +11,13 @@ module GrapeOAS
         # OAS3-specific fields: parameters (no body), requestBody, responses
         def build_version_specific_fields
           strategy = @options[:nullable_strategy] || Constants::NullableStrategy::KEYWORD
+          braces = @options[:array_use_braces] || false
 
           {
-            "parameters" => Parameter.new(@op, @ref_tracker, nullable_strategy: strategy).build,
-            "requestBody" => RequestBody.new(@op.request_body, @ref_tracker, nullable_strategy: strategy).build,
+            "parameters" => Parameter.new(@op, @ref_tracker, nullable_strategy: strategy,
+                                                             array_use_braces: braces,).build,
+            "requestBody" => RequestBody.new(@op.request_body, @ref_tracker, nullable_strategy: strategy,
+                                                                             array_use_braces: braces,).build,
             "responses" => Response.new(@op.responses, @ref_tracker, nullable_strategy: strategy).build
           }
         end

--- a/lib/grape_oas/exporter/oas3/parameter.rb
+++ b/lib/grape_oas/exporter/oas3/parameter.rb
@@ -4,10 +4,12 @@ module GrapeOAS
   module Exporter
     module OAS3
       class Parameter
-        def initialize(operation, ref_tracker = nil, nullable_strategy: Constants::NullableStrategy::KEYWORD)
+        def initialize(operation, ref_tracker = nil, nullable_strategy: Constants::NullableStrategy::KEYWORD,
+                       array_use_braces: false)
           @op = operation
           @ref_tracker = ref_tracker
           @nullable_strategy = nullable_strategy
+          @array_use_braces = array_use_braces
         end
 
         def build
@@ -16,7 +18,7 @@ module GrapeOAS
             schema_description = schema_hash.delete("description")
             description = param.description || schema_description
             {
-              "name" => param.name,
+              "name" => Base::ArrayBraces.param_name(param, enabled: @array_use_braces),
               "in" => param.location,
               "required" => param.required,
               "description" => description,

--- a/lib/grape_oas/exporter/oas3/paths.rb
+++ b/lib/grape_oas/exporter/oas3/paths.rb
@@ -12,6 +12,7 @@ module GrapeOAS
         def build_operation(operation)
           Operation.new(operation, @ref_tracker,
                         nullable_strategy: @options[:nullable_strategy] || Constants::NullableStrategy::KEYWORD,
+                        array_use_braces: @options[:array_use_braces] || false,
                         suppress_default_error_response: @options[:suppress_default_error_response],).build
         end
       end

--- a/lib/grape_oas/exporter/oas3/request_body.rb
+++ b/lib/grape_oas/exporter/oas3/request_body.rb
@@ -4,10 +4,12 @@ module GrapeOAS
   module Exporter
     module OAS3
       class RequestBody
-        def initialize(request_body, ref_tracker = nil, nullable_strategy: Constants::NullableStrategy::KEYWORD)
+        def initialize(request_body, ref_tracker = nil, nullable_strategy: Constants::NullableStrategy::KEYWORD,
+                       array_use_braces: false)
           @request_body = request_body
           @ref_tracker = ref_tracker
           @nullable_strategy = nullable_strategy
+          @array_use_braces = array_use_braces
         end
 
         def build
@@ -29,7 +31,7 @@ module GrapeOAS
           return nil unless media_types
 
           media_types.each_with_object({}) do |mt, h|
-            schema_entry = build_schema_or_ref(mt.schema)
+            schema_entry = build_schema_entry(mt)
             entry = {
               "schema" => schema_entry,
               "examples" => mt.examples
@@ -37,6 +39,18 @@ module GrapeOAS
             entry.merge!(mt.extensions) if mt.extensions&.any?
             h[mt.mime_type] = entry
           end
+        end
+
+        # When array_use_braces is on and this media type is form/multipart encoded, inline the
+        # schema (instead of emitting a shared $ref) so we can append `[]` to its array property
+        # names without affecting the JSON media type or the shared component schema.
+        def build_schema_entry(media_type)
+          if @array_use_braces && Base::ArrayBraces.form_encoded?(media_type.mime_type)
+            inline = Schema.new(media_type.schema, @ref_tracker, nullable_strategy: @nullable_strategy).build
+            return Base::ArrayBraces.apply_to_schema(inline)
+          end
+
+          build_schema_or_ref(media_type.schema)
         end
 
         def build_schema_or_ref(schema)

--- a/lib/grape_oas/exporter/oas3_schema.rb
+++ b/lib/grape_oas/exporter/oas3_schema.rb
@@ -20,6 +20,7 @@ module GrapeOAS
           "tags" => build_tags,
           "paths" => OAS3::Paths.new(@api, @ref_tracker,
                                      nullable_strategy: nullable_strategy,
+                                     array_use_braces: array_use_braces,
                                      suppress_default_error_response: @api.suppress_default_error_response,).build,
           "components" => build_components,
           "security" => build_security
@@ -121,6 +122,10 @@ module GrapeOAS
 
       def nullable_strategy
         @api.nullable_strategy || Constants::NullableStrategy::OAS3_DEFAULT
+      end
+
+      def array_use_braces
+        @api.array_use_braces || false
       end
     end
   end

--- a/test/e2e/generate_array_use_braces_test.rb
+++ b/test/e2e/generate_array_use_braces_test.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GrapeOAS
+  # End-to-end coverage for the `array_use_braces` option, which appends `[]`
+  # to the names of array parameters that are query-string params or
+  # form/multipart body properties. JSON bodies, scalar params, and path/header
+  # params are never modified.
+  class GenerateArrayUseBracesTest < Minitest::Test
+    class SampleAPI < Grape::API
+      format :json
+      content_type :json, "application/json"
+      content_type :form, "application/x-www-form-urlencoded"
+
+      desc "List items"
+      params do
+        optional :ids, type: [Integer], documentation: { param_type: "query" }
+        optional :name, type: String, documentation: { param_type: "query" }
+      end
+      get "items" do
+        {}
+      end
+
+      desc "Create item"
+      params do
+        requires :tags, type: [String]
+        requires :title, type: String
+      end
+      post "items" do
+        {}
+      end
+    end
+
+    def generate(version, **)
+      GrapeOAS.generate(app: SampleAPI, schema_type: version, **)
+    end
+
+    # ---- Query parameters -------------------------------------------
+
+    def test_oas2_array_query_param_gets_braces
+      params = generate(:oas2, array_use_braces: true)["paths"]["/items"]["get"]["parameters"]
+
+      assert(params.any? { |p| p["name"] == "ids[]" && p["in"] == "query" })
+      assert(params.any? { |p| p["name"] == "name" }, "scalar query param must stay unbraced")
+    end
+
+    def test_oas3_array_query_param_gets_braces
+      params = generate(:oas3, array_use_braces: true)["paths"]["/items"]["get"]["parameters"]
+
+      assert(params.any? { |p| p["name"] == "ids[]" && p["in"] == "query" })
+      assert(params.any? { |p| p["name"] == "name" })
+    end
+
+    def test_oas31_array_query_param_gets_braces
+      params = generate(:oas31, array_use_braces: true)["paths"]["/items"]["get"]["parameters"]
+
+      assert(params.any? { |p| p["name"] == "ids[]" })
+    end
+
+    def test_query_param_unchanged_when_option_off
+      %i[oas2 oas3 oas31].each do |version|
+        params = generate(version)["paths"]["/items"]["get"]["parameters"]
+
+        assert(params.any? { |p| p["name"] == "ids" }, "#{version}: array query param must be bare by default")
+        refute(params.any? { |p| p["name"] == "ids[]" }, "#{version}: must not add braces by default")
+      end
+    end
+
+    # ---- Form-encoded body ------------------------------------------
+
+    def test_oas3_form_body_array_property_gets_braces
+      content = generate(:oas3, array_use_braces: true)
+                .dig("paths", "/items", "post", "requestBody", "content")
+      form_schema = content["application/x-www-form-urlencoded"]["schema"]
+
+      assert_includes form_schema["properties"].keys, "tags[]"
+      assert_includes form_schema["properties"].keys, "title"
+      assert_includes form_schema["required"], "tags[]"
+      assert_includes form_schema["required"], "title"
+    end
+
+    def test_oas3_json_body_is_not_braced
+      content = generate(:oas3, array_use_braces: true)
+                .dig("paths", "/items", "post", "requestBody", "content")
+
+      # JSON body keeps the shared $ref; its properties live in components untouched.
+      assert content["application/json"]["schema"].key?("$ref"),
+             "JSON body must remain a $ref, not inlined with braces"
+    end
+
+    def test_oas2_form_body_array_property_gets_braces
+      params = generate(:oas2, array_use_braces: true)["paths"]["/items"]["post"]["parameters"]
+      body = params.find { |p| p["in"] == "body" }
+
+      assert_includes body.dig("schema", "properties").keys, "tags[]"
+      assert_includes body.dig("schema", "properties").keys, "title"
+      assert_includes body.dig("schema", "required"), "tags[]"
+    end
+
+    def test_form_body_unchanged_when_option_off
+      content = generate(:oas3)
+                .dig("paths", "/items", "post", "requestBody", "content")
+
+      assert content["application/x-www-form-urlencoded"]["schema"].key?("$ref"),
+             "form body must stay a $ref (no inlining/braces) by default"
+    end
+  end
+end

--- a/test/grape_oas/exporter/oas2_parameter_test.rb
+++ b/test/grape_oas/exporter/oas2_parameter_test.rb
@@ -529,6 +529,36 @@ module GrapeOAS
 
         refute status_param.key?("enum")
       end
+
+      def test_array_use_braces_appends_brackets_to_array_query_param
+        schema = ApiModel::Schema.new(type: "array", items: ApiModel::Schema.new(type: "string"))
+        param = ApiModel::Parameter.new(location: "query", name: "ids", schema: schema)
+        operation = ApiModel::Operation.new(http_method: "get", parameters: [param])
+
+        result = OAS2::Parameter.new(operation, nil, array_use_braces: true).build
+
+        assert(result.any? { |p| p["name"] == "ids[]" })
+      end
+
+      def test_array_use_braces_off_leaves_array_query_param_unchanged
+        schema = ApiModel::Schema.new(type: "array", items: ApiModel::Schema.new(type: "string"))
+        param = ApiModel::Parameter.new(location: "query", name: "ids", schema: schema)
+        operation = ApiModel::Operation.new(http_method: "get", parameters: [param])
+
+        result = OAS2::Parameter.new(operation, nil, array_use_braces: false).build
+
+        assert(result.any? { |p| p["name"] == "ids" })
+      end
+
+      def test_array_use_braces_ignores_non_array_query_param
+        schema = ApiModel::Schema.new(type: "string")
+        param = ApiModel::Parameter.new(location: "query", name: "name", schema: schema)
+        operation = ApiModel::Operation.new(http_method: "get", parameters: [param])
+
+        result = OAS2::Parameter.new(operation, nil, array_use_braces: true).build
+
+        assert(result.any? { |p| p["name"] == "name" })
+      end
     end
   end
 end

--- a/test/grape_oas/exporter/oas3_parameter_test.rb
+++ b/test/grape_oas/exporter/oas3_parameter_test.rb
@@ -58,6 +58,36 @@ module GrapeOAS
         refute size_param.key?("description")
         refute size_param["schema"].key?("description")
       end
+
+      def test_array_use_braces_appends_brackets_to_array_query_param
+        schema = ApiModel::Schema.new(type: "array", items: ApiModel::Schema.new(type: "string"))
+        param = ApiModel::Parameter.new(location: "query", name: "ids", schema: schema)
+        operation = ApiModel::Operation.new(http_method: "get", parameters: [param])
+
+        result = OAS3::Parameter.new(operation, nil, array_use_braces: true).build
+
+        assert_equal "ids[]", result.first["name"]
+      end
+
+      def test_array_use_braces_off_leaves_array_query_param_unchanged
+        schema = ApiModel::Schema.new(type: "array", items: ApiModel::Schema.new(type: "string"))
+        param = ApiModel::Parameter.new(location: "query", name: "ids", schema: schema)
+        operation = ApiModel::Operation.new(http_method: "get", parameters: [param])
+
+        result = OAS3::Parameter.new(operation, nil, array_use_braces: false).build
+
+        assert_equal "ids", result.first["name"]
+      end
+
+      def test_array_use_braces_ignores_non_array_query_param
+        schema = ApiModel::Schema.new(type: "string")
+        param = ApiModel::Parameter.new(location: "query", name: "name", schema: schema)
+        operation = ApiModel::Operation.new(http_method: "get", parameters: [param])
+
+        result = OAS3::Parameter.new(operation, nil, array_use_braces: true).build
+
+        assert_equal "name", result.first["name"]
+      end
     end
   end
 end

--- a/test/integration/documentation_extension_test.rb
+++ b/test/integration/documentation_extension_test.rb
@@ -347,6 +347,29 @@ class DocumentationExtensionTest < Minitest::Test
     assert_includes body["paths"].keys, "/ping"
   end
 
+  class ArrayUseBracesAPI < Grape::API
+    format :json
+
+    params do
+      optional :ids, type: [Integer], documentation: { param_type: "query" }
+    end
+    get "items" do
+      {}
+    end
+
+    add_oas_documentation(oas_mount_path: "/spec", array_use_braces: true)
+  end
+
+  def test_array_use_braces_passed_through_add_oas_documentation
+    resp = Rack::MockRequest.new(ArrayUseBracesAPI).get("/spec?oas=3")
+
+    assert_equal 200, resp.status
+    body = JSON.parse(resp.body)
+    names = body.dig("paths", "/items", "get", "parameters").map { |p| p["name"] }
+
+    assert_includes names, "ids[]", "array_use_braces should flow from add_oas_documentation to the output"
+  end
+
   class SwaggerCompatHideAPI < Grape::API
     format :json
     get("ping") { nil }


### PR DESCRIPTION
## Problem

Some clients (Rails/PHP/`qs`-style) expect array request fields to be named with a trailing `[]` — e.g. `ids[]` instead of `ids`. grape-oas always emits the bare Grape parameter name, so specs generated for these APIs don't reflect the wire format the server actually accepts.

## Fix

Add an opt-in boolean `array_use_braces` configuration option (default `false`, so existing output is unchanged). When enabled, it appends `[]` to the **name** of array parameters that are:

- query-string parameters (`in: query`), or
- body properties served under `application/x-www-form-urlencoded` or `multipart/form-data`.

JSON body properties (`application/json`), path params, and header params are never modified. The option is threaded from `GrapeOAS.generate` through the API model onto the exporters (mirroring `nullable_strategy`), and applies identically to OAS 2.0, 3.0, and 3.1.

Body schemas are auto-named and emitted as a shared `$ref` reused across every media type, so renaming property keys on that shared schema would corrupt the JSON representation. For a braced form/multipart media type the schema is therefore **inlined** and the rename applied to that copy; the JSON media type keeps its `$ref`. The `required` list is renamed in lockstep with the property keys. Only top-level form properties are braced (nested object structures, uncommon in form encodings, are left as-is).

## Example

```ruby
class API < Grape::API
  format :json
  content_type :form, "application/x-www-form-urlencoded"

  params do
    optional :ids, type: [Integer], documentation: { param_type: "query" }
  end
  get "items" do
    {}
  end

  params do
    requires :tags, type: [String]
    requires :title, type: String
  end
  post "items" do
    {}
  end
end

GrapeOAS.generate(app: API, schema_type: :oas3, array_use_braces: true)
```

## Schema before / after

Array query parameter (OAS 3.0/3.1; OAS 2.0 is equivalent with the name on the param object):

```jsonc
// before (array_use_braces: false, the default)
{ "name": "ids", "in": "query",
  "schema": { "type": "array", "items": { "type": "integer" } } }

// after (array_use_braces: true)
{ "name": "ids[]", "in": "query",
  "schema": { "type": "array", "items": { "type": "integer" } } }
```

Form-encoded body (OAS 3.x) — only the form media type is braced; JSON keeps its shared `$ref`:

```jsonc
// before
"requestBody": { "content": {
  "application/json":                  { "schema": { "$ref": "#/components/schemas/post_items_Request" } },
  "application/x-www-form-urlencoded": { "schema": { "$ref": "#/components/schemas/post_items_Request" } }
}}

// after
"requestBody": { "content": {
  "application/json": { "schema": { "$ref": "#/components/schemas/post_items_Request" } },
  "application/x-www-form-urlencoded": { "schema": {
    "type": "object",
    "properties": { "tags[]": { "type": "array", "items": { "type": "string" } },
                    "title":  { "type": "string" } },
    "required": ["tags[]", "title"]
  }}
}}
```

OAS 2.0 renders the form body as the single `in: body` schema; with the option on it is inlined with the same `tags[]` rename (including in `required`).

## Backward compatibility

Fully backward compatible. `array_use_braces` defaults to `false`; when unset, output is byte-for-byte identical to before. The braces only ever affect query params and form/multipart body property names when explicitly enabled.

## Open questions

- For OAS 2.0, form bodies are represented as a single `in: body` schema (existing grape-oas behavior, not individual `formData` params). Braces are applied to that body schema when the route consumes a form encoding. If a route consumes both JSON and a form encoding, the single OAS 2.0 body schema is shared, so enabling braces affects both — an inherent OAS 2.0 limitation. Flagging in case reviewers prefer scoping OAS 2.0 to query params only.