### PR TITLE
Fix array-valued parameter example truncation in OAS 3.0/3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#104](https://github.com/numbata/grape-oas/pull/104): Preserve array-valued parameter `example` in OAS 3.0/3.1 instead of truncating to the first element - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#97](https://github.com/numbata/grape-oas/pull/97): Default OAS 2.0 nullable strategy to EXTENSION so nullable fields emit `x-nullable: true` without explicit opt-in - [@numbata](https://github.com/numbata).
 - [#79](https://github.com/numbata/grape-oas/pull/79): Fix docs: `nickname` is supported in grape-oas - [@bogdan](https://github.com/bogdan).
 - [#78](https://github.com/numbata/grape-oas/pull/78): Fix: use empty schema for undocumented responses instead of `{ type: string }` - [@bogdan](https://github.com/bogdan).

--- a/lib/grape_oas/exporter/oas3/schema.rb
+++ b/lib/grape_oas/exporter/oas3/schema.rb
@@ -319,6 +319,11 @@ module GrapeOAS
         end
 
         def coerce_example(example, type_val)
+          # Composite examples (e.g. an array-valued example on an array schema,
+          # or a hash on an object schema) are passed through untouched; scalar
+          # coercion like #to_i only makes sense for scalar values.
+          return example if example.is_a?(Array) || example.is_a?(Hash)
+
           base_type = if type_val.is_a?(Array)
                         (type_val - ["null"]).first
                       else

--- a/lib/grape_oas/exporter/oas3/schema.rb
+++ b/lib/grape_oas/exporter/oas3/schema.rb
@@ -59,8 +59,10 @@ module GrapeOAS
         def apply_examples(schema_hash)
           return unless @schema.examples
 
-          examples = Array(@schema.examples).map { |ex| coerce_example(ex, schema_hash["type"]) }
-          schema_hash["example"] = examples.first
+          # A schema holds exactly one example value, which may itself be an
+          # array (e.g. an Array[String] parameter). Coerce and assign it as-is
+          # rather than treating it as a list of examples.
+          schema_hash["example"] = coerce_example(@schema.examples, schema_hash["type"])
         end
 
         def apply_extensions_and_extra_properties(schema_hash)

--- a/lib/grape_oas/exporter/oas31/schema.rb
+++ b/lib/grape_oas/exporter/oas31/schema.rb
@@ -13,10 +13,12 @@ module GrapeOAS
         def build
           hash = super
 
-          # swap example -> examples if present
+          # swap example -> examples if present. The OAS3 `example` is a single
+          # value, so wrap it as a one-element list (a value that is itself an
+          # array is one array-valued example, not many examples).
           if hash.key?("example")
             ex = hash.delete("example")
-            hash["examples"] ||= ex
+            hash["examples"] ||= [ex]
           end
           normalize_examples!(hash)
           hash

--- a/test/e2e/generate_array_string_param_example_test.rb
+++ b/test/e2e/generate_array_string_param_example_test.rb
@@ -48,5 +48,64 @@ module GrapeOAS
       # One array-valued example, not two scalar examples.
       assert_equal [%w[dog cat]], property["examples"]
     end
+
+    class IntegerArrayAPI < Grape::API
+      format :json
+
+      params do
+        requires :ages,
+                 type: [Integer],
+                 documentation: { example: [1, 2] }
+      end
+      post "people" do
+        {}
+      end
+    end
+
+    def test_oas3_preserves_integer_array_example
+      schema = GrapeOAS.generate(app: IntegerArrayAPI, schema_type: :oas3)
+      property = schema.dig("components", "schemas", "post_people_Request", "properties", "ages")
+
+      assert_equal "array", property["type"]
+      assert_equal "integer", property.dig("items", "type")
+      # Elements stay integers, and the array is not truncated.
+      assert_equal [1, 2], property["example"]
+    end
+
+    def test_oas31_wraps_integer_array_example
+      schema = GrapeOAS.generate(app: IntegerArrayAPI, schema_type: :oas31)
+      property = schema.dig("components", "schemas", "post_people_Request", "properties", "ages")
+
+      assert_equal "array", property["type"]
+      assert_equal "integer", property.dig("items", "type")
+      assert_equal [[1, 2]], property["examples"]
+    end
+
+    # Regression: an array example on a *scalar*-typed schema must not crash the
+    # exporter (coerce_example previously called Array#to_i). The input is
+    # malformed, but generation must succeed rather than raise.
+    class ScalarWithArrayExampleEntity < Grape::Entity
+      expose :status, documentation: { type: Integer, example: [1, 2] }
+    end
+
+    class ScalarExampleAPI < Grape::API
+      format :json
+
+      desc "list", entity: ScalarWithArrayExampleEntity
+      get "statuses" do
+        present({}, with: ScalarWithArrayExampleEntity)
+      end
+    end
+
+    def test_array_example_on_scalar_type_does_not_crash
+      %i[oas2 oas3 oas31].each do |version|
+        schema = GrapeOAS.generate(app: ScalarExampleAPI, schema_type: version)
+        schemas = schema["definitions"] || schema.dig("components", "schemas")
+        _key, entity_schema = schemas.find { |name, _| name.end_with?("ScalarWithArrayExampleEntity") }
+        property = entity_schema.dig("properties", "status")
+
+        assert_equal "integer", property["type"], "unexpected shape for #{version}"
+      end
+    end
   end
 end

--- a/test/e2e/generate_array_string_param_example_test.rb
+++ b/test/e2e/generate_array_string_param_example_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GrapeOAS
+  class GenerateArrayStringParamExampleTest < Minitest::Test
+    class SampleAPI < Grape::API
+      format :json
+
+      params do
+        requires :species,
+                 type: [String],
+                 documentation: { example: %w[dog cat] }
+      end
+      post "animals" do
+        {}
+      end
+    end
+
+    def test_oas2_preserves_full_array_example
+      schema = GrapeOAS.generate(app: SampleAPI, schema_type: :oas2)
+      property = schema.dig("definitions", "post_animals_Request", "properties", "species")
+
+      refute_nil property
+      assert_equal "array", property["type"]
+      assert_equal "string", property.dig("items", "type")
+      assert_equal %w[dog cat], property["example"]
+    end
+
+    def test_oas3_preserves_full_array_example
+      schema = GrapeOAS.generate(app: SampleAPI, schema_type: :oas3)
+      property = schema.dig("components", "schemas", "post_animals_Request", "properties", "species")
+
+      refute_nil property
+      assert_equal "array", property["type"]
+      assert_equal "string", property.dig("items", "type")
+      # Regression: was truncated to "dog" by Array(@schema.examples).first.
+      assert_equal %w[dog cat], property["example"]
+    end
+
+    def test_oas31_wraps_array_example_as_single_example
+      schema = GrapeOAS.generate(app: SampleAPI, schema_type: :oas31)
+      property = schema.dig("components", "schemas", "post_animals_Request", "properties", "species")
+
+      refute_nil property
+      assert_equal "array", property["type"]
+      assert_equal "string", property.dig("items", "type")
+      # One array-valued example, not two scalar examples.
+      assert_equal [%w[dog cat]], property["examples"]
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Declaring an array parameter with an example value silently drops all but
the first element in OAS 3.0 and 3.1 output:

```ruby
requires :species, type: Array[String], documentation: { example: ["dog", "cat"] }
```

The builder attaches the example to the array schema as a single value, but
the OAS 3.0 exporter passed it through `Array(@schema.examples).first`, which
treats the one array-valued example as a list of scalar examples and keeps
only `"dog"`. OAS 3.1 inherited that truncated value and re-wrapped it. OAS
2.0 was already correct. There is no multi-example feature at the
parameter/schema level (named/multiple examples exist only on the response
path), so the `Array(...)` coercion had no legitimate purpose.

## Fix

A schema's `examples` attribute always holds exactly one example value, which
may itself be an array. The OAS 3.0 exporter now coerces and assigns that
single value directly instead of splitting it. The OAS 3.1 exporter wraps the
single value in a one-element list (`[ex]`) so a value that happens to be an
array is emitted as one array-valued example, not many. OAS 2.0 is unchanged.

`coerce_example` now passes composite (array/hash) example values through
untouched — scalar coercion (`#to_i` / `#to_f`) only applies to scalar values.
Without this guard, an array example on a *scalar*-typed schema (e.g. a
property typed `integer` with `example: [1, 2]`) raised
`NoMethodError: undefined method 'to_i' for an instance of Array` during
export. The previous `Array(...).first` form masked that by splitting the
array into scalars first. Such input is malformed (an array is not a valid
example for an integer), but generation must succeed rather than crash.

## Example

```ruby
class API < Grape::API
  format :json

  params do
    requires :species, type: [String], documentation: { example: %w[dog cat] }
  end
  post("animals") { {} }
end
```

## Schema before / after

```yaml
# OAS 3.0 — Before: array example truncated to its first element
species:
  type: array
  items: { type: string }
  example: dog

# OAS 3.0 — After: full array preserved
species:
  type: array
  items: { type: string }
  example: [dog, cat]
```

```yaml
# OAS 3.1 — Before: truncated, then wrapped as a single scalar example
species:
  type: array
  items: { type: string }
  examples: [dog]

# OAS 3.1 — After: one array-valued example
species:
  type: array
  items: { type: string }
  examples:
    - [dog, cat]
```

```yaml
# OAS 2.0 — unchanged (already correct)
species:
  type: array
  items: { type: string }
  example: [dog, cat]
```

## Backward compatibility

- Public API surface: unchanged.
- Emitted OAS shape for inputs that don't exercise this fix: unchanged — scalar
  examples produce identical output in all three versions; only array-valued
  examples were affected.
- New runtime/dev dependencies: none.

## Open questions

Two edge cases are intentionally out of scope here:

- Coercing array *element* types against `items` (e.g. `["1","2"]` -> `[1,2]`
  for `Array[Integer]`) is a pre-existing limitation, left untouched.
- An array example on a scalar-typed schema is now passed through as-is rather
  than crashing. It's technically an invalid example for that type; the
  exporter doesn't try to "fix" malformed input. Worth a separate
  warning/issue, or fine as GIGO?