### PR TITLE
Place array-valued entity example on the array schema, not items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#85](https://github.com/numbata/grape-oas/pull/85): Honor `is_array: true` on the plain-entity response branch - [@abeljim8am](https://github.com/abeljim8am).
 - [#87](https://github.com/numbata/grape-oas/pull/87): Fix `SchemaIndexer#index_schema` to recurse into `schema.items` so entities reachable only through an array wrapper (e.g. a property declared as `Array<OtherEntity>`) are included in the indexed schemas set - [@abeljim8am](https://github.com/abeljim8am).
 - [#102](https://github.com/numbata/grape-oas/pull/102): Fix: nullable entity ref must not mutate shared cached schema - [@bogdan](https://github.com/bogdan).
-- [#105](https://github.com/numbata/grape-oas/pull/105): Place array-valued `example` on the array schema instead of `items` for entity `is_array:` exposures - [@olivier-thatch](https://github.com/olivier-thatch).
+- [#105](https://github.com/numbata/grape-oas/pull/105): Place array-valued `example` on the array schema instead of `items` for entity `is_array:` exposures without mutating shared entity schemas - [@olivier-thatch](https://github.com/olivier-thatch).
 * Your contribution here
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#85](https://github.com/numbata/grape-oas/pull/85): Honor `is_array: true` on the plain-entity response branch - [@abeljim8am](https://github.com/abeljim8am).
 - [#87](https://github.com/numbata/grape-oas/pull/87): Fix `SchemaIndexer#index_schema` to recurse into `schema.items` so entities reachable only through an array wrapper (e.g. a property declared as `Array<OtherEntity>`) are included in the indexed schemas set - [@abeljim8am](https://github.com/abeljim8am).
 - [#102](https://github.com/numbata/grape-oas/pull/102): Fix: nullable entity ref must not mutate shared cached schema - [@bogdan](https://github.com/bogdan).
+- [#105](https://github.com/numbata/grape-oas/pull/105): Place array-valued `example` on the array schema instead of `items` for entity `is_array:` exposures - [@olivier-thatch](https://github.com/olivier-thatch).
 * Your contribution here
 
 ### Changed

--- a/lib/grape_oas/introspectors/entity_introspector_support/exposure_processor.rb
+++ b/lib/grape_oas/introspectors/entity_introspector_support/exposure_processor.rb
@@ -158,7 +158,19 @@ module GrapeOAS
           is_array = doc[:is_array]
           return prop_schema unless is_array
 
-          ApiModel::Schema.new(type: Constants::SchemaTypes::ARRAY, items: prop_schema)
+          array_schema = ApiModel::Schema.new(type: Constants::SchemaTypes::ARRAY, items: prop_schema)
+          hoist_array_example(array_schema, prop_schema)
+          array_schema
+        end
+
+        # An array-valued example describes the whole array, not one element, so move
+        # it from the item schema to the array wrapper. Scalar examples stay on the
+        # item schema, where they are a valid example for a single element.
+        def hoist_array_example(array_schema, item_schema)
+          return unless item_schema.respond_to?(:examples) && item_schema.examples.is_a?(Array)
+
+          array_schema.examples = item_schema.examples
+          item_schema.examples = nil
         end
 
         # Detects block-based nesting exposures (NestingExposure) that should become

--- a/lib/grape_oas/introspectors/entity_introspector_support/exposure_processor.rb
+++ b/lib/grape_oas/introspectors/entity_introspector_support/exposure_processor.rb
@@ -159,18 +159,11 @@ module GrapeOAS
           return prop_schema unless is_array
 
           array_schema = ApiModel::Schema.new(type: Constants::SchemaTypes::ARRAY, items: prop_schema)
-          hoist_array_example(array_schema, prop_schema)
+          if doc[:example].is_a?(Array)
+            array_schema.examples = doc[:example]
+            prop_schema.examples = nil
+          end
           array_schema
-        end
-
-        # An array-valued example describes the whole array, not one element, so move
-        # it from the item schema to the array wrapper. Scalar examples stay on the
-        # item schema, where they are a valid example for a single element.
-        def hoist_array_example(array_schema, item_schema)
-          return unless item_schema.respond_to?(:examples) && item_schema.examples.is_a?(Array)
-
-          array_schema.examples = item_schema.examples
-          item_schema.examples = nil
         end
 
         # Detects block-based nesting exposures (NestingExposure) that should become

--- a/lib/grape_oas/introspectors/entity_introspector_support/exposure_processor.rb
+++ b/lib/grape_oas/introspectors/entity_introspector_support/exposure_processor.rb
@@ -278,6 +278,9 @@ module GrapeOAS
           return schema unless schema.respond_to?(:examples=)
 
           if schema.respond_to?(:canonical_name) && schema.canonical_name
+            GrapeOAS.logger.warn(
+              "Duplicating cached schema '#{schema.canonical_name}' to apply example #{example.inspect}",
+            )
             schema = schema.dup
             schema.canonical_name = nil
           end

--- a/lib/grape_oas/introspectors/entity_introspector_support/exposure_processor.rb
+++ b/lib/grape_oas/introspectors/entity_introspector_support/exposure_processor.rb
@@ -159,10 +159,7 @@ module GrapeOAS
           return prop_schema unless is_array
 
           array_schema = ApiModel::Schema.new(type: Constants::SchemaTypes::ARRAY, items: prop_schema)
-          if doc[:example].is_a?(Array)
-            array_schema.examples = doc[:example]
-            prop_schema.examples = nil
-          end
+          array_schema.examples = doc[:example] if array_valued_example?(doc)
           array_schema
         end
 
@@ -231,7 +228,7 @@ module GrapeOAS
           end
           schema.description = doc[:desc] if doc[:desc]
           schema.format = doc[:format] if doc[:format]
-          schema.examples = doc[:example] if schema.respond_to?(:examples=) && doc[:example]
+          schema = apply_example_to_schema(schema, doc[:example]) if doc[:example] && !array_valued_example?(doc)
           schema.additional_properties = doc[:additional_properties] if doc.key?(:additional_properties)
           schema.unevaluated_properties = doc[:unevaluated_properties] if doc.key?(:unevaluated_properties)
           defs = doc[:defs] || doc[:$defs]
@@ -275,6 +272,21 @@ module GrapeOAS
             schema.enum = values
           end
           schema
+        end
+
+        def apply_example_to_schema(schema, example)
+          return schema unless schema.respond_to?(:examples=)
+
+          if schema.respond_to?(:canonical_name) && schema.canonical_name
+            schema = schema.dup
+            schema.canonical_name = nil
+          end
+          schema.examples = example
+          schema
+        end
+
+        def array_valued_example?(doc)
+          doc[:is_array] && doc[:example].is_a?(Array)
         end
 
         def normalize_doc_keys(doc)

--- a/lib/grape_oas/introspectors/entity_introspector_support/exposure_processor.rb
+++ b/lib/grape_oas/introspectors/entity_introspector_support/exposure_processor.rb
@@ -239,17 +239,24 @@ module GrapeOAS
         end
 
         # Cached entity schemas (via using:) are shared across all exposures that
-        # reference the same entity — dup before setting enum to avoid mutating
-        # the shared schema; emit a warning so users know a dup occurred.
+        # reference the same entity — dup before mutating them (enum, example, ...)
+        # to avoid corrupting the shared schema; emit a warning so users know a
+        # dup occurred.
         #
+        # @return [ApiModel::Schema] a dup of schema with canonical_name cleared
+        def dup_cached_schema(schema, reason:, value:)
+          GrapeOAS.logger.warn(
+            "Duplicating cached schema '#{schema.canonical_name}' to apply #{reason} #{value.inspect}",
+          )
+          dup = schema.dup
+          dup.canonical_name = nil
+          dup
+        end
+
         # @return [ApiModel::Schema] the schema (or a dup) with enum applied
         def apply_enum_to_schema(schema, values)
           if schema.respond_to?(:canonical_name) && schema.canonical_name
-            GrapeOAS.logger.warn(
-              "Duplicating cached schema '#{schema.canonical_name}' to apply enum #{values.inspect}",
-            )
-            schema = schema.dup
-            schema.canonical_name = nil
+            schema = dup_cached_schema(schema, reason: "enum", value: values)
             schema.enum = values
             return schema
           end
@@ -257,13 +264,9 @@ module GrapeOAS
           if schema.type == Constants::SchemaTypes::ARRAY &&
              schema.respond_to?(:items) && schema.items
             if schema.items.respond_to?(:canonical_name) && schema.items.canonical_name
-              GrapeOAS.logger.warn(
-                "Duplicating cached schema '#{schema.items.canonical_name}' to apply enum #{values.inspect}",
-              )
-              schema = schema.dup
-              items_dup = schema.items.dup
-              items_dup.canonical_name = nil
+              items_dup = dup_cached_schema(schema.items, reason: "enum", value: values)
               items_dup.enum = values
+              schema = schema.dup
               schema.items = items_dup
             else
               schema.items.enum = values
@@ -278,16 +281,14 @@ module GrapeOAS
           return schema unless schema.respond_to?(:examples=)
 
           if schema.respond_to?(:canonical_name) && schema.canonical_name
-            GrapeOAS.logger.warn(
-              "Duplicating cached schema '#{schema.canonical_name}' to apply example #{example.inspect}",
-            )
-            schema = schema.dup
-            schema.canonical_name = nil
+            schema = dup_cached_schema(schema, reason: "example", value: example)
           end
           schema.examples = example
           schema
         end
 
+        # True when doc[:example] describes the whole array (not a single item),
+        # i.e. is_array: true and the example is itself an Array.
         def array_valued_example?(doc)
           doc[:is_array] && doc[:example].is_a?(Array)
         end

--- a/test/grape_oas/introspectors/entity_introspector_array_example_test.rb
+++ b/test/grape_oas/introspectors/entity_introspector_array_example_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GrapeOAS
+  module Introspectors
+    class EntityIntrospectorArrayExampleTest < Minitest::Test
+      # is_array: true with an array-valued example — example belongs on the array wrapper.
+
+      class ArrayExampleEntity < Grape::Entity
+        expose :species, documentation: { type: "string", is_array: true, example: %w[cat dog] }
+        expose :counts,  documentation: { type: "integer", is_array: true, example: [1, 2] }
+      end
+
+      def test_array_valued_string_example_is_placed_on_array_schema
+        schema = EntityIntrospector.new(ArrayExampleEntity).build_schema
+        species = schema.properties["species"]
+
+        assert_equal Constants::SchemaTypes::ARRAY, species.type
+        assert_equal %w[cat dog], species.examples
+        assert_nil species.items.examples
+      end
+
+      def test_array_valued_integer_example_is_placed_on_array_schema
+        schema = EntityIntrospector.new(ArrayExampleEntity).build_schema
+        counts = schema.properties["counts"]
+
+        assert_equal Constants::SchemaTypes::ARRAY, counts.type
+        assert_equal [1, 2], counts.examples
+        assert_nil counts.items.examples
+      end
+
+      # is_array: true with a scalar example — example stays on items (valid per OAS).
+
+      class ScalarExampleOnArrayEntity < Grape::Entity
+        expose :label, documentation: { type: "string", is_array: true, example: "cat" }
+      end
+
+      def test_scalar_example_on_is_array_exposure_stays_on_items
+        schema = EntityIntrospector.new(ScalarExampleOnArrayEntity).build_schema
+        label = schema.properties["label"]
+
+        assert_equal Constants::SchemaTypes::ARRAY, label.type
+        assert_nil label.examples
+        assert_equal "cat", label.items.examples
+      end
+    end
+  end
+end

--- a/test/grape_oas/introspectors/entity_introspector_array_example_test.rb
+++ b/test/grape_oas/introspectors/entity_introspector_array_example_test.rb
@@ -54,6 +54,11 @@ module GrapeOAS
                       documentation: { is_array: true, example: [{ "name" => "Ada" }, { "name" => "Lin" }] }
       end
 
+      class ScalarExampleOnReferencedArrayEntity < Grape::Entity
+        expose :plain, using: ReferencedEntity
+        expose :list, using: ReferencedEntity, documentation: { is_array: true, example: { "name" => "Ada" } }
+      end
+
       def test_scalar_example_on_is_array_exposure_stays_on_items
         schema = EntityIntrospector.new(ScalarExampleOnArrayEntity).build_schema
         label = schema.properties["label"]
@@ -89,6 +94,21 @@ module GrapeOAS
         assert_equal [{ "name" => "Ada" }, { "name" => "Lin" }], list.examples
         assert_nil list.items.examples
         refute_same single, list.items
+      end
+
+      def test_scalar_example_on_array_of_shared_entity_does_not_mutate_other_exposure
+        schema = nil
+        log = capture_grape_oas_log do
+          schema = EntityIntrospector.new(ScalarExampleOnReferencedArrayEntity).build_schema
+        end
+        plain = schema.properties["plain"]
+        list = schema.properties["list"]
+
+        assert_nil plain.examples
+        assert_nil list.examples
+        assert_equal({ "name" => "Ada" }, list.items.examples)
+        refute_same plain, list.items
+        assert_match(/Duplicating cached schema/, log)
       end
     end
   end

--- a/test/grape_oas/introspectors/entity_introspector_array_example_test.rb
+++ b/test/grape_oas/introspectors/entity_introspector_array_example_test.rb
@@ -36,6 +36,10 @@ module GrapeOAS
         expose :label, documentation: { type: "string", is_array: true, example: "cat" }
       end
 
+      class NoExampleEntity < Grape::Entity
+        expose :tags, documentation: { type: "string", is_array: true }
+      end
+
       def test_scalar_example_on_is_array_exposure_stays_on_items
         schema = EntityIntrospector.new(ScalarExampleOnArrayEntity).build_schema
         label = schema.properties["label"]
@@ -43,6 +47,15 @@ module GrapeOAS
         assert_equal Constants::SchemaTypes::ARRAY, label.type
         assert_nil label.examples
         assert_equal "cat", label.items.examples
+      end
+
+      def test_is_array_exposure_without_example_produces_no_examples
+        schema = EntityIntrospector.new(NoExampleEntity).build_schema
+        tags = schema.properties["tags"]
+
+        assert_equal Constants::SchemaTypes::ARRAY, tags.type
+        assert_nil tags.examples
+        assert_nil tags.items.examples
       end
     end
   end

--- a/test/grape_oas/introspectors/entity_introspector_array_example_test.rb
+++ b/test/grape_oas/introspectors/entity_introspector_array_example_test.rb
@@ -40,6 +40,20 @@ module GrapeOAS
         expose :tags, documentation: { type: "string", is_array: true }
       end
 
+      class EmptyArrayExampleEntity < Grape::Entity
+        expose :tags, documentation: { type: "string", is_array: true, example: [] }
+      end
+
+      class ReferencedEntity < Grape::Entity
+        expose :name, documentation: { type: "string" }
+      end
+
+      class SharedEntityExampleEntity < Grape::Entity
+        expose :single, using: ReferencedEntity, documentation: { example: { "name" => "Ada" } }
+        expose :list, using: ReferencedEntity,
+                      documentation: { is_array: true, example: [{ "name" => "Ada" }, { "name" => "Lin" }] }
+      end
+
       def test_scalar_example_on_is_array_exposure_stays_on_items
         schema = EntityIntrospector.new(ScalarExampleOnArrayEntity).build_schema
         label = schema.properties["label"]
@@ -56,6 +70,25 @@ module GrapeOAS
         assert_equal Constants::SchemaTypes::ARRAY, tags.type
         assert_nil tags.examples
         assert_nil tags.items.examples
+      end
+
+      def test_empty_array_example_is_placed_on_array_schema
+        schema = EntityIntrospector.new(EmptyArrayExampleEntity).build_schema
+        tags = schema.properties["tags"]
+
+        assert_equal [], tags.examples
+        assert_nil tags.items.examples
+      end
+
+      def test_array_example_does_not_mutate_shared_entity_schema
+        schema = EntityIntrospector.new(SharedEntityExampleEntity).build_schema
+        single = schema.properties["single"]
+        list = schema.properties["list"]
+
+        assert_equal({ "name" => "Ada" }, single.examples)
+        assert_equal [{ "name" => "Ada" }, { "name" => "Lin" }], list.examples
+        assert_nil list.items.examples
+        refute_same single, list.items
       end
     end
   end

--- a/test/grape_oas/introspectors/entity_introspector_nesting_exposure_test.rb
+++ b/test/grape_oas/introspectors/entity_introspector_nesting_exposure_test.rb
@@ -102,6 +102,12 @@ module GrapeOAS
         end
       end
 
+      class ArrayExampleNestingEntity < Grape::Entity
+        expose :items, documentation: { is_array: true, example: [{ "id" => 1 }, { "id" => 2 }] } do
+          expose :id, documentation: { type: Integer }
+        end
+      end
+
       def test_nesting_exposure_with_array_wrapper
         schema = EntityIntrospector.new(ArrayNestingEntity).build_schema
 
@@ -112,6 +118,14 @@ module GrapeOAS
         assert_includes items.items.properties.keys, "id"
         assert_includes items.items.properties.keys, "status"
         assert_equal %w[active inactive], items.items.properties["status"].enum
+      end
+
+      def test_nesting_exposure_array_example_is_placed_on_array_wrapper
+        schema = EntityIntrospector.new(ArrayExampleNestingEntity).build_schema
+        items = schema.properties["items"]
+
+        assert_equal [{ "id" => 1 }, { "id" => 2 }], items.examples
+        assert_nil items.items.examples
       end
 
       # === Mixed: nesting exposure with using: entity child ===


### PR DESCRIPTION
## Problem

A `grape-entity` exposure declared as an array via `is_array: true` that
also carries an `example:` attaches the array-valued example to the wrong
schema node. The example lands on the inner (scalar) `items` schema, which
is then wrapped as `items` inside the array. The result is a semantically
invalid schema: a scalar `items` whose `example` is the whole array.

## Fix

`apply_exposure_properties` sets the example on the inner schema *before*
`wrap_in_array_if_needed` wraps it as `items`, so the example follows the
inner schema down into `items`. The fix hoists the example back up: when
wrapping an exposure in an array, an **array-valued** example is moved from
the item schema to the array wrapper and cleared from the item schema. A
**scalar** example is left on the item schema, where it remains a valid
example for a single element — so existing behavior for scalar examples is
unchanged.

This is an introspector-layer fix only. It does not touch the exporters.

## Example

```ruby
class AnimalEntity < Grape::Entity
  expose :species, documentation: { type: "string", is_array: true, example: ["cat", "dog"] }
end

class API < Grape::API
  format :json
  desc "list", entity: AnimalEntity
  get("animals") { present({}, with: AnimalEntity) }
end
```

## Schema before / after

OAS 2.0 (`species` property), which renders the array-valued example
end-to-end:

```yaml
# Before — scalar `items` with an array-valued example (invalid)
species:
  type: array
  items:
    type: string
    example:
      - cat
      - dog

# After — example describes the whole array, so it sits on the array node
species:
  type: array
  items:
    type: string
  example:
    - cat
    - dog
```

At the introspector layer (`EntityIntrospector#build_schema`), the same
relocation holds for all three versions: `species.examples == ["cat","dog"]`
and `species.items.examples == nil`. For OAS 3.0/3.1 the array example is
further mangled by a *separate* exporter truncation bug, tracked and fixed
in #104 — that is a different layer and out of scope here.

## Backward compatibility

- Public API surface: unchanged.
- Emitted OAS shape for inputs that don't exercise this fix: unchanged.
  Only entity `is_array:` exposures carrying an **array-valued** example
  change shape — the example moves from `items` up to the array node.
  Scalar examples on `is_array:` exposures are untouched (they stay on
  `items`).
- New runtime/dev dependencies: none.

## Open questions

OAS 3.0/3.1 array-example truncation in the exporter is a separate bug
(#104). This PR is intentionally independent of it and is verified at the
introspector/unit level so it stands alone off `main`.