### PR TITLE
Apply nullable to the array, not its items, on is_array exposures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#82](https://github.com/numbata/grape-oas/pull/82): Fix: respect `documentation: { hidden: true }` on entity exposures - [@bogdan](https://github.com/bogdan).
 - [#80](https://github.com/numbata/grape-oas/pull/80): Fix: hide documentation routes from generated spec by default - [@bogdan](https://github.com/bogdan).
 - [#98](https://github.com/numbata/grape-oas/pull/98): Honor `documentation: { x: { nullable: true } }` on entity exposures - [@olivier-thatch](https://github.com/olivier-thatch).
+- [#106](https://github.com/numbata/grape-oas/pull/106): Apply `nullable` to the array, not its items, on `is_array: true` entity exposures - [@olivier-thatch](https://github.com/olivier-thatch).
 - [#85](https://github.com/numbata/grape-oas/pull/85): Honor `is_array: true` on the plain-entity response branch - [@abeljim8am](https://github.com/abeljim8am).
 - [#87](https://github.com/numbata/grape-oas/pull/87): Fix `SchemaIndexer#index_schema` to recurse into `schema.items` so entities reachable only through an array wrapper (e.g. a property declared as `Array<OtherEntity>`) are included in the indexed schemas set - [@abeljim8am](https://github.com/abeljim8am).
 * Your contribution here

--- a/lib/grape_oas/introspectors/entity_introspector_support/exposure_processor.rb
+++ b/lib/grape_oas/introspectors/entity_introspector_support/exposure_processor.rb
@@ -158,7 +158,12 @@ module GrapeOAS
           is_array = doc[:is_array]
           return prop_schema unless is_array
 
-          ApiModel::Schema.new(type: Constants::SchemaTypes::ARRAY, items: prop_schema)
+          array_schema = ApiModel::Schema.new(type: Constants::SchemaTypes::ARRAY, items: prop_schema)
+          # nullable describes the array itself, not its elements: a nullable
+          # array may be null, but its items remain non-null.
+          array_schema.nullable = prop_schema.nullable
+          prop_schema.nullable = false
+          array_schema
         end
 
         # Detects block-based nesting exposures (NestingExposure) that should become

--- a/test/grape_oas/introspectors/entity_introspector_test.rb
+++ b/test/grape_oas/introspectors/entity_introspector_test.rb
@@ -195,6 +195,20 @@ module GrapeOAS
         assert note_schema.nullable, "Expected x: { nullable: true } to set schema.nullable on entity exposure"
       end
 
+      def test_nullable_array_marks_array_not_items
+        entity_class = Class.new(Grape::Entity) do
+          expose :species, documentation: { type: "string", is_array: true, x: { nullable: true } }
+        end
+
+        schema = Introspectors::EntityIntrospector.new(entity_class).build_schema
+        species = schema.properties["species"]
+
+        assert_equal "array", species.type
+        assert species.nullable, "Expected the array itself to be nullable"
+        assert_equal "string", species.items.type
+        refute species.items.nullable, "Expected array items to remain non-nullable"
+      end
+
       def test_merge_flattens_properties
         schema = Introspectors::EntityIntrospector.new(ConditionalEntity).build_schema
 


### PR DESCRIPTION
## Problem

An entity exposure that is both an array (`is_array: true`) and nullable
applied the nullable flag to the array's **items** rather than to the
array itself. The intent of a nullable array is that the array value may
be `null`, not that each element may be `null`.

## Fix

`wrap_in_array_if_needed` (in `exposure_processor.rb`) now transfers the
`nullable` flag from the inner item schema onto the outer array schema it
creates, and clears it on the items. This covers both the plain-entity and
nesting-exposure paths, since both route through `build_property_schema`.
Item-level concerns such as `values`/enum are unaffected.

## Example

```ruby
class AnimalEntity < Grape::Entity
  expose :species, documentation: { type: "string", is_array: true, x: { nullable: true } }
end
```

## Schema before / after

OAS 3.0:
```diff
 "species": {
   "type": "array",
-  "items": { "type": "string", "nullable": true }
+  "nullable": true,
+  "items": { "type": "string" }
 }
```

OAS 2.0:
```diff
 "species": {
   "type": "array",
-  "items": { "type": "string", "x-nullable": true }
+  "x-nullable": true,
+  "items": { "type": "string" }
 }
```

OAS 3.1:
```diff
 "species": {
-  "type": "array",
-  "items": { "type": ["string", "null"] }
+  "type": ["array", "null"],
+  "items": { "type": "string" }
 }
```

## Backward compatibility

This changes generated output for exposures that combine `is_array: true`
with a nullable flag. Specs that (incorrectly) relied on the item-level
nullable will see it move to the array level. No public API changes; no
other nullable or array behavior is affected.
